### PR TITLE
Cached `ISerDesSelector` instances across application, bump version to 2.3.0

### DIFF
--- a/src/net/Common/Common.props
+++ b/src/net/Common/Common.props
@@ -4,7 +4,7 @@
 		<Owners>MASES s.r.l.</Owners>
 		<Authors>MASES s.r.l.</Authors>
 		<Company>MASES s.r.l.</Company>
-		<Version>2.2.0.0</Version>
+		<Version>2.3.0.0</Version>
 		<TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>

--- a/src/net/KEFCore/Infrastructure/Internal/KafkaOptionsExtension.cs
+++ b/src/net/KEFCore/Infrastructure/Internal/KafkaOptionsExtension.cs
@@ -62,8 +62,6 @@ public class KafkaOptionsExtension : IDbContextOptionsExtension, IKafkaSingleton
     private Action<EntityTypeChanged>? _onChangeEvent = null;
     private DbContextOptionsExtensionInfo? _info;
 
-    static readonly Java.Lang.ClassLoader _loader = Java.Lang.ClassLoader.SystemClassLoader;
-    internal static Java.Lang.ClassLoader SystemClassLoader => _loader;
     /// <summary>
     /// Initializer
     /// </summary>
@@ -360,15 +358,16 @@ public class KafkaOptionsExtension : IDbContextOptionsExtension, IKafkaSingleton
 
         builder.ApplicationId = ApplicationId;
         builder.BootstrapServers = BootstrapServers;
+
         string baSerdesName = Class.ClassNameOf<Org.Apache.Kafka.Common.Serialization.Serdes.ByteArraySerde>();
         string bbSerdesName = Class.ClassNameOf<MASES.KNet.Serialization.Serdes.ByteBufferSerde>();
 
-        builder.DefaultKeySerdeClass = this.JVMKeyType(entityType) == typeof(byte[]) ? Class.ForName(baSerdesName, true, SystemClassLoader)
-                                                                                     : Class.ForName(bbSerdesName, true, SystemClassLoader);
-        builder.DefaultValueSerdeClass = this.JVMValueContainerType(entityType) == typeof(byte[]) ? Class.ForName(baSerdesName, true, SystemClassLoader)
-                                                                                                  : Class.ForName(bbSerdesName, true, SystemClassLoader);
-        builder.DSLStoreSuppliersClass = UsePersistentStorage ? Class.ForName(Class.ClassNameOf<BuiltInDslStoreSuppliers.RocksDBDslStoreSuppliers>(), true, SystemClassLoader)
-                                                              : Class.ForName(Class.ClassNameOf<BuiltInDslStoreSuppliers.InMemoryDslStoreSuppliers>(), true, SystemClassLoader);
+        builder.DefaultKeySerdeClass = this.JVMKeyType(entityType) == typeof(byte[]) ? Class.ForName(baSerdesName, true, Class.SystemClassLoader)
+                                                                                     : Class.ForName(bbSerdesName, true, Class.SystemClassLoader);
+        builder.DefaultValueSerdeClass = this.JVMValueContainerType(entityType) == typeof(byte[]) ? Class.ForName(baSerdesName, true, Class.SystemClassLoader)
+                                                                                                  : Class.ForName(bbSerdesName, true, Class.SystemClassLoader);
+        builder.DSLStoreSuppliersClass = UsePersistentStorage ? Class.ForName(Class.ClassNameOf<BuiltInDslStoreSuppliers.RocksDBDslStoreSuppliers>(), true, Class.SystemClassLoader)
+                                                              : Class.ForName(Class.ClassNameOf<BuiltInDslStoreSuppliers.InMemoryDslStoreSuppliers>(), true, Class.SystemClassLoader);
 
         //if (props.ContainsKey(Org.Apache.Kafka.Streams.StreamsConfig.APPLICATION_ID_CONFIG))
         //{
@@ -419,12 +418,12 @@ public class KafkaOptionsExtension : IDbContextOptionsExtension, IKafkaSingleton
         {
             props.Remove(Org.Apache.Kafka.Streams.StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG);
         }
-        props.Put(Org.Apache.Kafka.Streams.StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Class.ForName("org.apache.kafka.common.serialization.Serdes$ByteArraySerde", true, SystemClassLoader));
+        props.Put(Org.Apache.Kafka.Streams.StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Class.ForName("org.apache.kafka.common.serialization.Serdes$ByteArraySerde", true, Class.SystemClassLoader));
         if (props.ContainsKey(Org.Apache.Kafka.Streams.StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG))
         {
             props.Remove(Org.Apache.Kafka.Streams.StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG);
         }
-        props.Put(Org.Apache.Kafka.Streams.StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Class.ForName("org.apache.kafka.common.serialization.Serdes$ByteArraySerde", true, SystemClassLoader));
+        props.Put(Org.Apache.Kafka.Streams.StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Class.ForName("org.apache.kafka.common.serialization.Serdes$ByteArraySerde", true, Class.SystemClassLoader));
         if (props.ContainsKey(Org.Apache.Kafka.Clients.Consumer.ConsumerConfig.AUTO_OFFSET_RESET_CONFIG))
         {
             props.Remove(Org.Apache.Kafka.Clients.Consumer.ConsumerConfig.AUTO_OFFSET_RESET_CONFIG);

--- a/src/net/KEFCore/Infrastructure/KafkaDbContext.cs
+++ b/src/net/KEFCore/Infrastructure/KafkaDbContext.cs
@@ -227,7 +227,6 @@ const bool perf = false;
     /// Use KNet version of Apache Kafka Streams instead of standard Apache Kafka Streams
     /// </summary>
     public virtual bool UseKNetStreams { get; set; } = true;
-
     /// <summary>
     /// The optional <see cref="ConsumerConfigBuilder"/> used when <see cref="UseCompactedReplicator"/> is <see langword="true"/>
     /// </summary>
@@ -264,7 +263,8 @@ const bool perf = false;
             o.WithStreamsConfig(StreamsConfig ?? DefaultStreamsConfig).WithDefaultNumPartitions(DefaultNumPartitions);
             o.WithTopicConfig(TopicConfig ?? DefaultTopicConfig);
             o.WithUsePersistentStorage(UsePersistentStorage);
-        o.WithUseEnumeratorWithPrefetch(UseEnumeratorWithPrefetch);
+            o.WithUseEnumeratorWithPrefetch(UseEnumeratorWithPrefetch);
+            o.WithUseByteBufferDataTransfer(UseByteBufferDataTransfer);
             o.WithUseDeletePolicyForTopic(UseDeletePolicyForTopic);
             o.WithCompactedReplicator(UseCompactedReplicator);
             o.WithUseKNetStreams(UseKNetStreams);

--- a/src/net/KEFCore/Storage/Internal/EntityTypeProducers.cs
+++ b/src/net/KEFCore/Storage/Internal/EntityTypeProducers.cs
@@ -35,13 +35,11 @@ public class EntityTypeProducers
     /// <summary>
     /// Allocates a new <see cref="IEntityTypeProducer"/>
     /// </summary>
-    public static IEntityTypeProducer Create<TKey, TValueContainer, TJVMKey, TJVMValueContainer, TKeySerDesSelectorType, TValueContainerSerDesSelectorType>(IEntityType entityType, IKafkaCluster cluster)
+    public static IEntityTypeProducer Create<TKey, TValueContainer, TJVMKey, TJVMValueContainer>(IEntityType entityType, IKafkaCluster cluster)
         where TKey : notnull
         where TValueContainer : class, IValueContainer<TKey>
-        where TKeySerDesSelectorType : class, ISerDesSelector<TKey>, new()
-        where TValueContainerSerDesSelectorType : class, ISerDesSelector<TValueContainer>, new()
     {
-        return _producers.GetOrAdd(entityType, _ => CreateProducerLocal<TKey, TValueContainer, TJVMKey, TJVMValueContainer, TKeySerDesSelectorType, TValueContainerSerDesSelectorType>(entityType, cluster));
+        return _producers.GetOrAdd(entityType, _ => CreateProducerLocal<TKey, TValueContainer, TJVMKey, TJVMValueContainer>(entityType, cluster));
     }
     /// <summary>
     /// Dispose a previously allocated <see cref="IEntityTypeProducer"/>
@@ -55,10 +53,8 @@ public class EntityTypeProducers
         producer.Dispose();
     }
 
-    static IEntityTypeProducer CreateProducerLocal<TKey, TValueContainer, TJVMKey, TJVMValueContainer, TKeySerDesSelectorType, TValueContainerSerDesSelectorType>(IEntityType entityType, IKafkaCluster cluster)
+    static IEntityTypeProducer CreateProducerLocal<TKey, TValueContainer, TJVMKey, TJVMValueContainer>(IEntityType entityType, IKafkaCluster cluster)
         where TKey : notnull
         where TValueContainer : class, IValueContainer<TKey>
-        where TKeySerDesSelectorType : class, ISerDesSelector<TKey>, new()
-        where TValueContainerSerDesSelectorType : class, ISerDesSelector<TValueContainer>, new()
-        => new EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContainer, TKeySerDesSelectorType, TValueContainerSerDesSelectorType>(entityType, cluster);
+        => new EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContainer>(entityType, cluster);
 }

--- a/src/net/KEFCore/Storage/Internal/KafkaTable.cs
+++ b/src/net/KEFCore/Storage/Internal/KafkaTable.cs
@@ -34,11 +34,9 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-public class KafkaTable<TKey, TValueContainer, TJVMKey, TJVMValueContainer, TKeySerDesSelectorType, TValueContainerSerDesSelectorType> : IKafkaTable
+public class KafkaTable<TKey, TValueContainer, TJVMKey, TJVMValueContainer> : IKafkaTable
     where TKey : notnull
     where TValueContainer : class, IValueContainer<TKey>
-    where TKeySerDesSelectorType : class, ISerDesSelector<TKey>, new()
-    where TValueContainerSerDesSelectorType : class, ISerDesSelector<TValueContainer>, new()
 {
     private readonly IPrincipalKeyValueFactory<TKey> _keyValueFactory;
     private readonly bool _sensitiveLoggingEnabled;
@@ -63,7 +61,7 @@ public class KafkaTable<TKey, TValueContainer, TJVMKey, TJVMValueContainer, TKey
         Cluster = cluster;
         EntityType = entityType;
         _tableAssociatedTopicName = Cluster.CreateTable(entityType);
-        _producer = EntityTypeProducers.Create<TKey, TValueContainer, TJVMKey, TJVMValueContainer, TKeySerDesSelectorType, TValueContainerSerDesSelectorType>(entityType, Cluster);
+        _producer = EntityTypeProducers.Create<TKey, TValueContainer, TJVMKey, TJVMValueContainer>(entityType, Cluster);
         _keyValueFactory = entityType.FindPrimaryKey()!.GetPrincipalKeyValueFactory<TKey>();
         _sensitiveLoggingEnabled = sensitiveLoggingEnabled;
         _rows = new Dictionary<TKey, object?[]>(_keyValueFactory.EqualityComparer);

--- a/src/net/KEFCore/Storage/Internal/KafkaTableFactory.cs
+++ b/src/net/KEFCore/Storage/Internal/KafkaTableFactory.cs
@@ -59,18 +59,14 @@ public class KafkaTableFactory : IKafkaTableFactory
             .MakeGenericMethod(entityType.FindPrimaryKey()!.GetKeyType(), 
                                _options.ValueContainerType(entityType),
                                _options.JVMKeyType(entityType),
-                               _options.JVMValueContainerType(entityType),
-                               _options.SerDesSelectorTypeForKey(entityType), 
-                               _options.SerDesSelectorTypeForValue(entityType))
+                               _options.JVMValueContainerType(entityType))
             .Invoke(null, new object?[] { cluster, entityType, _sensitiveLoggingEnabled })!;
 
-    private static Func<IKafkaTable> CreateFactory<TKey, TValueContainer, TJVMKey, TJVMValueContainer, TKeySerDesSelectorType, TValueContainerSerDesSelectorType>(
+    private static Func<IKafkaTable> CreateFactory<TKey, TValueContainer, TJVMKey, TJVMValueContainer>(
         IKafkaCluster cluster,
         IEntityType entityType,
         bool sensitiveLoggingEnabled)
         where TKey : notnull
         where TValueContainer : class, IValueContainer<TKey>
-        where TKeySerDesSelectorType : class, ISerDesSelector<TKey>, new()
-        where TValueContainerSerDesSelectorType : class, ISerDesSelector<TValueContainer>, new()
-        => () => new KafkaTable<TKey, TValueContainer, TJVMKey, TJVMValueContainer, TKeySerDesSelectorType, TValueContainerSerDesSelectorType>(cluster, entityType, sensitiveLoggingEnabled);
+        => () => new KafkaTable<TKey, TValueContainer, TJVMKey, TJVMValueContainer>(cluster, entityType, sensitiveLoggingEnabled);
 }

--- a/src/net/templates/templates/kefcoreApp/kefcoreApp.csproj
+++ b/src/net/templates/templates/kefcoreApp/kefcoreApp.csproj
@@ -9,6 +9,6 @@
 	</ItemGroup>
 	<ItemGroup Condition="!Exists('..\..\..\KEFCore\KEFCore.csproj')">
 		<!--Outside GitHub repo-->
-		<PackageReference Include="MASES.EntityFrameworkCore.KNet" Version="2.2.0" IncludeAssets="All" PrivateAssets="None" />
+		<PackageReference Include="MASES.EntityFrameworkCore.KNet" Version="2.3.0" IncludeAssets="All" PrivateAssets="None" />
 	</ItemGroup>
 </Project>

--- a/src/net/templates/templates/kefcoreAppWithEvents/kefcoreAppWithEvents.csproj
+++ b/src/net/templates/templates/kefcoreAppWithEvents/kefcoreAppWithEvents.csproj
@@ -9,6 +9,6 @@
 	</ItemGroup>
 	<ItemGroup Condition="!Exists('..\..\..\KEFCore\KEFCore.csproj')">
 		<!--Outside GitHub repo-->
-		<PackageReference Include="MASES.EntityFrameworkCore.KNet" Version="2.2.0" IncludeAssets="All" PrivateAssets="None" />
+		<PackageReference Include="MASES.EntityFrameworkCore.KNet" Version="2.3.0" IncludeAssets="All" PrivateAssets="None" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR adds a cache of `ISerDesSelector` based on `IEntityType`, this changes removes the need of generic type in classes related to `ISerDesSelector` classes.

The version becomes 2.3.0 due to breaking changes in serialization selection

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
