### PR TITLE
Bump version to 2.5.2 in props and templates

### DIFF
--- a/src/net/Common/Common.props
+++ b/src/net/Common/Common.props
@@ -4,7 +4,7 @@
 		<Owners>MASES s.r.l.</Owners>
 		<Authors>MASES s.r.l.</Authors>
 		<Company>MASES s.r.l.</Company>
-		<Version>2.5.1.0</Version>
+		<Version>2.5.2.0</Version>
 		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>

--- a/src/net/templates/templates/kefcoreApp/kefcoreApp.csproj
+++ b/src/net/templates/templates/kefcoreApp/kefcoreApp.csproj
@@ -9,6 +9,6 @@
 	</ItemGroup>
 	<ItemGroup Condition="!Exists('..\..\..\KEFCore\KEFCore.csproj')">
 		<!--Outside GitHub repo-->
-		<PackageReference Include="MASES.EntityFrameworkCore.KNet" Version="2.5.1" IncludeAssets="All" PrivateAssets="None" />
+		<PackageReference Include="MASES.EntityFrameworkCore.KNet" Version="2.5.2" IncludeAssets="All" PrivateAssets="None" />
 	</ItemGroup>
 </Project>

--- a/src/net/templates/templates/kefcoreAppWithEvents/kefcoreAppWithEvents.csproj
+++ b/src/net/templates/templates/kefcoreAppWithEvents/kefcoreAppWithEvents.csproj
@@ -9,6 +9,6 @@
 	</ItemGroup>
 	<ItemGroup Condition="!Exists('..\..\..\KEFCore\KEFCore.csproj')">
 		<!--Outside GitHub repo-->
-		<PackageReference Include="MASES.EntityFrameworkCore.KNet" Version="2.5.1" IncludeAssets="All" PrivateAssets="None" />
+		<PackageReference Include="MASES.EntityFrameworkCore.KNet" Version="2.5.2" IncludeAssets="All" PrivateAssets="None" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updated Common.props and template project files to reference version 2.5.2 of MASES.EntityFrameworkCore.KNet. This ensures consistency and access to the latest package updates.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
fix #254
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
