### PR TITLE
Respect [Table] attribute for topic names

### DIFF
--- a/src/net/KEFCore/Extensions/KafkaEntityTypeExtensions.cs
+++ b/src/net/KEFCore/Extensions/KafkaEntityTypeExtensions.cs
@@ -19,6 +19,7 @@
 using MASES.EntityFrameworkCore.KNet.Infrastructure.Internal;
 using MASES.EntityFrameworkCore.KNet.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace MASES.EntityFrameworkCore.KNet;
 
@@ -77,7 +78,13 @@ public static class KafkaEntityTypeExtensions
     /// </summary>
     public static string TopicName(this IEntityType entityType, KafkaOptionsExtension options)
     {
-        return $"{options.DatabaseName}.{entityType.Name}";
+        var schema = entityType.Name;
+        var table = entityType.ClrType.GetCustomAttribute<TableAttribute>();
+        if (table != null)
+        {
+            schema = table.Schema != null ? $"{table.Schema}.{table.Name}" : $"{table.Name}";
+        }
+        return $"{options.DatabaseName}.{schema}";
     }
     /// <summary>
     /// Creates the storage id

--- a/test/Common/Model.cs
+++ b/test/Common/Model.cs
@@ -24,9 +24,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace MASES.EntityFrameworkCore.KNet.Test.Model
 {
+    [Table("Blog", Schema = "Simple")]
     public class Blog
     {
         public int BlogId { get; set; }
@@ -39,7 +41,7 @@ namespace MASES.EntityFrameworkCore.KNet.Test.Model
             return $"BlogId: {BlogId} Url: {Url} Rating: {Rating}";
         }
     }
-
+    [Table("Post", Schema = "Simple")]
     public class Post
     {
         public int PostId { get; set; }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use System.ComponentModel.DataAnnotations.Schema.TableAttribute when generating Kafka topic names. KafkaEntityTypeExtensions.TopicName now checks the entity CLR type for a [Table] attribute and uses its Schema and Name (formatted as "Schema.Name" or "Name" if no schema) when building the topic name prefixed by options.DatabaseName. Tests updated to annotate Blog and Post with [Table("...", Schema = "Simple")] and added the required using directive.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
closed #417
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
