### PR TITLE
Make ClrType optional for well-known types

### DIFF
--- a/src/net/KEFCore.SerDes.Avro/AvroValueContainer.avsc
+++ b/src/net/KEFCore.SerDes.Avro/AvroValueContainer.avsc
@@ -47,8 +47,9 @@
 						},
 						{
 							"name": "ClrType",
-							"doc": "Represents the CLR type of the property in the EF Core schema of the EntityType",
-							"type": "string"
+							"doc": "Represents the CLR type of the property in the EF Core schema of the EntityType, null for well-known types",
+							"type": [ "null", "string" ],
+							"default": null
 						},
 						{
 							"name": "Value",

--- a/src/net/KEFCore.SerDes.Avro/AvroValueContainer.cs
+++ b/src/net/KEFCore.SerDes.Avro/AvroValueContainer.cs
@@ -80,7 +80,7 @@ public partial class AvroValueContainer<TKey> : AvroValueContainer, IValueContai
                 ManagedType = (int)_type.Item1,
                 SupportNull = _type.Item2,
                 PropertyName = item.Name,
-                ClrType = item.ClrType?.ToAssemblyQualified(),
+                ClrType = _type.Item1 == NativeTypeMapper.ManagedTypes.Undefined ? item.ClrType?.ToAssemblyQualified() : null,
                 Value = value
             };
             Data.Add(pRecord);

--- a/src/net/KEFCore.SerDes.Avro/Generated/AvroValueContainer.cs
+++ b/src/net/KEFCore.SerDes.Avro/Generated/AvroValueContainer.cs
@@ -19,7 +19,26 @@ namespace MASES.EntityFrameworkCore.KNet.Serialization.Avro.Storage
 	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("MASES.EntityFrameworkCore.KNet.Serialization.Avro.Compiler", "1.12.1+9110c693767c1dde2665b2b57939333478b12036")]
 	public partial class AvroValueContainer : global::Avro.Specific.ISpecificRecord
 	{
-		public static global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(@"{""type"":""record"",""name"":""AvroValueContainer"",""doc"":""Represents the storage container type to be used from KEFCore values"",""namespace"":""MASES.EntityFrameworkCore.KNet.Serialization.Avro.Storage"",""fields"":[{""name"":""EntityName"",""doc"":""Represents the entity name of the Entity in the EF Core schema of the EntityType"",""type"":""string""},{""name"":""ClrType"",""doc"":""Represents the CLR type of the Entity in the EF Core schema of the EntityType"",""type"":""string""},{""name"":""Data"",""type"":{""type"":""array"",""items"":{""type"":""record"",""name"":""PropertyDataRecord"",""doc"":""Represents the single container for Entity properties stored in AvroValueContainer and used from KEFCore"",""namespace"":""MASES.EntityFrameworkCore.KNet.Serialization.Avro.Storage"",""fields"":[{""name"":""PropertyIndex"",""doc"":""Represents the index of the property in the EF Core schema of the EntityType"",""default"":null,""type"":[""null"",""int""]},{""name"":""PropertyName"",""doc"":""Represents the name of the property in the EF Core schema of the EntityType"",""type"":""string""},{""name"":""ManagedType"",""doc"":""Represents the internal KEFCore type associated to the property in the EF Core schema of the EntityType"",""type"":""int""},{""name"":""SupportNull"",""doc"":""true if the ManagedType shall support null, e.g. Nullable type in .NET"",""type"":""boolean""},{""name"":""ClrType"",""doc"":""Represents the CLR type of the property in the EF Core schema of the EntityType"",""type"":""string""},{""name"":""Value"",""type"":[""null"",""boolean"",""int"",""long"",""float"",""double"",""string""]}]}}}]}");
+		public static global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse("{\"type\":\"record\",\"name\":\"AvroValueContainer\",\"doc\":\"Represents the storage contai" +
+				"ner type to be used from KEFCore values\",\"namespace\":\"MASES.EntityFrameworkCore." +
+				"KNet.Serialization.Avro.Storage\",\"fields\":[{\"name\":\"EntityName\",\"doc\":\"Represent" +
+				"s the entity name of the Entity in the EF Core schema of the EntityType\",\"type\":" +
+				"\"string\"},{\"name\":\"ClrType\",\"doc\":\"Represents the CLR type of the Entity in the " +
+				"EF Core schema of the EntityType\",\"type\":\"string\"},{\"name\":\"Data\",\"type\":{\"type\"" +
+				":\"array\",\"items\":{\"type\":\"record\",\"name\":\"PropertyDataRecord\",\"doc\":\"Represents " +
+				"the single container for Entity properties stored in AvroValueContainer and used" +
+				" from KEFCore\",\"namespace\":\"MASES.EntityFrameworkCore.KNet.Serialization.Avro.St" +
+				"orage\",\"fields\":[{\"name\":\"PropertyIndex\",\"doc\":\"Represents the index of the prop" +
+				"erty in the EF Core schema of the EntityType\",\"default\":null,\"type\":[\"null\",\"int" +
+				"\"]},{\"name\":\"PropertyName\",\"doc\":\"Represents the name of the property in the EF " +
+				"Core schema of the EntityType\",\"type\":\"string\"},{\"name\":\"ManagedType\",\"doc\":\"Rep" +
+				"resents the internal KEFCore type associated to the property in the EF Core sche" +
+				"ma of the EntityType\",\"type\":\"int\"},{\"name\":\"SupportNull\",\"doc\":\"true if the Man" +
+				"agedType shall support null, e.g. Nullable type in .NET\",\"type\":\"boolean\"},{\"nam" +
+				"e\":\"ClrType\",\"doc\":\"Represents the CLR type of the property in the EF Core schem" +
+				"a of the EntityType, null for well-known types\",\"default\":null,\"type\":[\"null\",\"s" +
+				"tring\"]},{\"name\":\"Value\",\"type\":[\"null\",\"boolean\",\"int\",\"long\",\"float\",\"double\"," +
+				"\"string\"]}]}}}]}");
 		/// <summary>
 		/// Represents the entity name of the Entity in the EF Core schema of the EntityType
 		/// </summary>

--- a/src/net/KEFCore.SerDes.Avro/Generated/PropertyDataRecord.cs
+++ b/src/net/KEFCore.SerDes.Avro/Generated/PropertyDataRecord.cs
@@ -19,7 +19,7 @@ namespace MASES.EntityFrameworkCore.KNet.Serialization.Avro.Storage
 	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("MASES.EntityFrameworkCore.KNet.Serialization.Avro.Compiler", "1.12.1+9110c693767c1dde2665b2b57939333478b12036")]
 	public partial class PropertyDataRecord : global::Avro.Specific.ISpecificRecord
 	{
-		public static global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(@"{""type"":""record"",""name"":""PropertyDataRecord"",""doc"":""Represents the single container for Entity properties stored in AvroValueContainer and used from KEFCore"",""namespace"":""MASES.EntityFrameworkCore.KNet.Serialization.Avro.Storage"",""fields"":[{""name"":""PropertyIndex"",""doc"":""Represents the index of the property in the EF Core schema of the EntityType"",""default"":null,""type"":[""null"",""int""]},{""name"":""PropertyName"",""doc"":""Represents the name of the property in the EF Core schema of the EntityType"",""type"":""string""},{""name"":""ManagedType"",""doc"":""Represents the internal KEFCore type associated to the property in the EF Core schema of the EntityType"",""type"":""int""},{""name"":""SupportNull"",""doc"":""true if the ManagedType shall support null, e.g. Nullable type in .NET"",""type"":""boolean""},{""name"":""ClrType"",""doc"":""Represents the CLR type of the property in the EF Core schema of the EntityType"",""type"":""string""},{""name"":""Value"",""type"":[""null"",""boolean"",""int"",""long"",""float"",""double"",""string""]}]}");
+		public static global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(@"{""type"":""record"",""name"":""PropertyDataRecord"",""doc"":""Represents the single container for Entity properties stored in AvroValueContainer and used from KEFCore"",""namespace"":""MASES.EntityFrameworkCore.KNet.Serialization.Avro.Storage"",""fields"":[{""name"":""PropertyIndex"",""doc"":""Represents the index of the property in the EF Core schema of the EntityType"",""default"":null,""type"":[""null"",""int""]},{""name"":""PropertyName"",""doc"":""Represents the name of the property in the EF Core schema of the EntityType"",""type"":""string""},{""name"":""ManagedType"",""doc"":""Represents the internal KEFCore type associated to the property in the EF Core schema of the EntityType"",""type"":""int""},{""name"":""SupportNull"",""doc"":""true if the ManagedType shall support null, e.g. Nullable type in .NET"",""type"":""boolean""},{""name"":""ClrType"",""doc"":""Represents the CLR type of the property in the EF Core schema of the EntityType, null for well-known types"",""default"":null,""type"":[""null"",""string""]},{""name"":""Value"",""type"":[""null"",""boolean"",""int"",""long"",""float"",""double"",""string""]}]}");
 		/// <summary>
 		/// Represents the index of the property in the EF Core schema of the EntityType
 		/// </summary>
@@ -37,7 +37,7 @@ namespace MASES.EntityFrameworkCore.KNet.Serialization.Avro.Storage
 		/// </summary>
 		private bool _SupportNull;
 		/// <summary>
-		/// Represents the CLR type of the property in the EF Core schema of the EntityType
+		/// Represents the CLR type of the property in the EF Core schema of the EntityType, null for well-known types
 		/// </summary>
 		private string _ClrType;
 		private object _Value;
@@ -105,7 +105,7 @@ namespace MASES.EntityFrameworkCore.KNet.Serialization.Avro.Storage
 			}
 		}
 		/// <summary>
-		/// Represents the CLR type of the property in the EF Core schema of the EntityType
+		/// Represents the CLR type of the property in the EF Core schema of the EntityType, null for well-known types
 		/// </summary>
 		public string ClrType
 		{

--- a/src/net/KEFCore.SerDes.Protobuf/Generated/ValueContainer.cs
+++ b/src/net/KEFCore.SerDes.Protobuf/Generated/ValueContainer.cs
@@ -25,19 +25,20 @@ namespace MASES.EntityFrameworkCore.KNet.Serialization.Protobuf.Storage {
       byte[] descriptorData = global::System.Convert.FromBase64String(
           string.Concat(
             "ChRWYWx1ZUNvbnRhaW5lci5wcm90bxIHc3RvcmFnZRoSR2VuZXJpY1ZhbHVl",
-            "LnByb3RvIo8BChJQcm9wZXJ0eURhdGFSZWNvcmQSGgoNUHJvcGVydHlJbmRl",
-            "eBgBIAEoBUgAiAEBEhQKDFByb3BlcnR5TmFtZRgCIAEoCRIPCgdDbHJUeXBl",
-            "GAMgASgJEiQKBVZhbHVlGAQgASgLMhUuc3RvcmFnZS5HZW5lcmljVmFsdWVC",
-            "EAoOX1Byb3BlcnR5SW5kZXgiYAoOVmFsdWVDb250YWluZXISEgoKRW50aXR5",
-            "TmFtZRgBIAEoCRIPCgdDbHJUeXBlGAIgASgJEikKBERhdGEYAyADKAsyGy5z",
-            "dG9yYWdlLlByb3BlcnR5RGF0YVJlY29yZEKJAQo1bWFzZXMuZW50aXR5ZnJh",
-            "bWV3b3JrY29yZS5rbmV0LnNlcmlhbGl6YXRpb24ucHJvdG9idWZCDlZhbHVl",
-            "Q29udGFpbmVyUAGqAj1NQVNFUy5FbnRpdHlGcmFtZXdvcmtDb3JlLktOZXQu",
-            "U2VyaWFsaXphdGlvbi5Qcm90b2J1Zi5TdG9yYWdlYgZwcm90bzM="));
+            "LnByb3RvIqABChJQcm9wZXJ0eURhdGFSZWNvcmQSGgoNUHJvcGVydHlJbmRl",
+            "eBgBIAEoBUgAiAEBEhQKDFByb3BlcnR5TmFtZRgCIAEoCRIUCgdDbHJUeXBl",
+            "GAMgASgJSAGIAQESJAoFVmFsdWUYBCABKAsyFS5zdG9yYWdlLkdlbmVyaWNW",
+            "YWx1ZUIQCg5fUHJvcGVydHlJbmRleEIKCghfQ2xyVHlwZSJgCg5WYWx1ZUNv",
+            "bnRhaW5lchISCgpFbnRpdHlOYW1lGAEgASgJEg8KB0NsclR5cGUYAiABKAkS",
+            "KQoERGF0YRgDIAMoCzIbLnN0b3JhZ2UuUHJvcGVydHlEYXRhUmVjb3JkQokB",
+            "CjVtYXNlcy5lbnRpdHlmcmFtZXdvcmtjb3JlLmtuZXQuc2VyaWFsaXphdGlv",
+            "bi5wcm90b2J1ZkIOVmFsdWVDb250YWluZXJQAaoCPU1BU0VTLkVudGl0eUZy",
+            "YW1ld29ya0NvcmUuS05ldC5TZXJpYWxpemF0aW9uLlByb3RvYnVmLlN0b3Jh",
+            "Z2ViBnByb3RvMw=="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::MASES.EntityFrameworkCore.KNet.Serialization.Protobuf.Storage.GenericValueReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, null, new pbr::GeneratedClrTypeInfo[] {
-            new pbr::GeneratedClrTypeInfo(typeof(global::MASES.EntityFrameworkCore.KNet.Serialization.Protobuf.Storage.PropertyDataRecord), global::MASES.EntityFrameworkCore.KNet.Serialization.Protobuf.Storage.PropertyDataRecord.Parser, new[]{ "PropertyIndex", "PropertyName", "ClrType", "Value" }, new[]{ "PropertyIndex" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::MASES.EntityFrameworkCore.KNet.Serialization.Protobuf.Storage.PropertyDataRecord), global::MASES.EntityFrameworkCore.KNet.Serialization.Protobuf.Storage.PropertyDataRecord.Parser, new[]{ "PropertyIndex", "PropertyName", "ClrType", "Value" }, new[]{ "PropertyIndex", "ClrType" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::MASES.EntityFrameworkCore.KNet.Serialization.Protobuf.Storage.ValueContainer), global::MASES.EntityFrameworkCore.KNet.Serialization.Protobuf.Storage.ValueContainer.Parser, new[]{ "EntityName", "ClrType", "Data" }, null, null, null, null)
           }));
     }
@@ -139,14 +140,28 @@ namespace MASES.EntityFrameworkCore.KNet.Serialization.Protobuf.Storage {
 
     /// <summary>Field number for the "ClrType" field.</summary>
     public const int ClrTypeFieldNumber = 3;
-    private string clrType_ = "";
+    private readonly static string ClrTypeDefaultValue = "";
+
+    private string clrType_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public string ClrType {
-      get { return clrType_; }
+      get { return clrType_ ?? ClrTypeDefaultValue; }
       set {
         clrType_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
+    }
+    /// <summary>Gets whether the "ClrType" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasClrType {
+      get { return clrType_ != null; }
+    }
+    /// <summary>Clears the value of the "ClrType" field</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearClrType() {
+      clrType_ = null;
     }
 
     /// <summary>Field number for the "Value" field.</summary>
@@ -189,7 +204,7 @@ namespace MASES.EntityFrameworkCore.KNet.Serialization.Protobuf.Storage {
       int hash = 1;
       if (HasPropertyIndex) hash ^= PropertyIndex.GetHashCode();
       if (PropertyName.Length != 0) hash ^= PropertyName.GetHashCode();
-      if (ClrType.Length != 0) hash ^= ClrType.GetHashCode();
+      if (HasClrType) hash ^= ClrType.GetHashCode();
       if (value_ != null) hash ^= Value.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
@@ -217,7 +232,7 @@ namespace MASES.EntityFrameworkCore.KNet.Serialization.Protobuf.Storage {
         output.WriteRawTag(18);
         output.WriteString(PropertyName);
       }
-      if (ClrType.Length != 0) {
+      if (HasClrType) {
         output.WriteRawTag(26);
         output.WriteString(ClrType);
       }
@@ -243,7 +258,7 @@ namespace MASES.EntityFrameworkCore.KNet.Serialization.Protobuf.Storage {
         output.WriteRawTag(18);
         output.WriteString(PropertyName);
       }
-      if (ClrType.Length != 0) {
+      if (HasClrType) {
         output.WriteRawTag(26);
         output.WriteString(ClrType);
       }
@@ -267,7 +282,7 @@ namespace MASES.EntityFrameworkCore.KNet.Serialization.Protobuf.Storage {
       if (PropertyName.Length != 0) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(PropertyName);
       }
-      if (ClrType.Length != 0) {
+      if (HasClrType) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(ClrType);
       }
       if (value_ != null) {
@@ -291,7 +306,7 @@ namespace MASES.EntityFrameworkCore.KNet.Serialization.Protobuf.Storage {
       if (other.PropertyName.Length != 0) {
         PropertyName = other.PropertyName;
       }
-      if (other.ClrType.Length != 0) {
+      if (other.HasClrType) {
         ClrType = other.ClrType;
       }
       if (other.value_ != null) {

--- a/src/net/KEFCore.SerDes.Protobuf/Storage/ProtobufGenericValue.cs
+++ b/src/net/KEFCore.SerDes.Protobuf/Storage/ProtobufGenericValue.cs
@@ -19,6 +19,7 @@
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using System.Globalization;
+using static MASES.EntityFrameworkCore.KNet.Serialization.NativeTypeMapper;
 
 namespace MASES.EntityFrameworkCore.KNet.Serialization.Protobuf.Storage
 {
@@ -52,19 +53,18 @@ namespace MASES.EntityFrameworkCore.KNet.Serialization.Protobuf.Storage
         /// </summary>
         /// <param name="input">The value to insert</param>
         /// <exception cref="InvalidOperationException"></exception>
-        public GenericValue(object input) : this(input?.GetType(), input)
+        public GenericValue(object input) : this(NativeTypeMapper.GetValue(input?.GetType()), input)
         {
         }
 
         /// <summary>
         /// Initializer for <paramref name="input"/>
         /// </summary>
-        /// <param name="clrType">The <see cref="System.Type"/></param>
+        /// <param name="_type">The <see cref="System.Type"/></param>
         /// <param name="input">The value to insert</param>
         /// <exception cref="InvalidOperationException"></exception>
-        public GenericValue(System.Type? clrType, object? input)
+        public GenericValue((ManagedTypes, bool) _type, object? input)
         {
-            var _type = NativeTypeMapper.GetValue(clrType);
             ManagedType = (int)_type.Item1;
             SupportNull = _type.Item2;
 

--- a/src/net/KEFCore.SerDes.Protobuf/Storage/ProtobufValueContainer.cs
+++ b/src/net/KEFCore.SerDes.Protobuf/Storage/ProtobufValueContainer.cs
@@ -67,11 +67,12 @@ public class ProtobufValueContainer<TKey> : IMessage<ProtobufValueContainer<TKey
         foreach (var item in properties)
         {
             int index = item.GetIndex();
+            var _type = NativeTypeMapper.GetValue(item.ClrType!);
             var pRecord = new PropertyDataRecord
             {
                 PropertyName = item.Name,
-                ClrType = item.ClrType?.ToAssemblyQualified(),
-                Value = new GenericValue(item.ClrType!, rData[index])
+                ClrType = _type.Item1 == NativeTypeMapper.ManagedTypes.Undefined ? item.ClrType?.ToAssemblyQualified() : string.Empty,
+                Value = new GenericValue(_type, rData[index])
             };
             _innerMessage.Data.Add(pRecord);
         }

--- a/src/net/KEFCore.SerDes.Protobuf/ValueContainer.proto
+++ b/src/net/KEFCore.SerDes.Protobuf/ValueContainer.proto
@@ -27,7 +27,7 @@ option csharp_namespace = "MASES.EntityFrameworkCore.KNet.Serialization.Protobuf
 message PropertyDataRecord {
   optional int32 PropertyIndex = 1;
   string PropertyName = 2;
-  string ClrType = 3;
+  optional string ClrType = 3;
   GenericValue Value = 4;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Treat ClrType as nullable/optional for well-known/native types across Avro, Protobuf and JSON containers. Updated Avro schema and generated Avro types to use [null,string] with default null and only emit ClrType for undefined/native mappings. Changed .proto to make ClrType optional and regenerated Protobuf code to add presence handling (HasClrType/ClearClrType), null-aware serialization/deserialization and adjusted hashing/equality/merge logic. Updated GenericValue/ValueContainer constructors and callers to use NativeTypeMapper.GetValue((ManagedTypes,bool)) and pass the type tuple, and adjusted DefaultValueContainer deserialization to prefer native type mapping and to ignore empty/null ClrType when serializing JSON (JsonIgnoreWhenWritingNull). These changes avoid storing assembly-qualified CLR names for well-known types and centralize native type handling.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
closed #423 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
