### PR TITLE
Update creation offsets and sync check

### DIFF
--- a/src/net/KEFCore/Storage/Internal/StreamsManager.cs
+++ b/src/net/KEFCore/Storage/Internal/StreamsManager.cs
@@ -83,6 +83,31 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
             public readonly IDictionary<int, long> CreationKnownOffset = creationKnownOffset; // expected to be invariant
             public readonly IDictionary<int, long> LatestKnownOffset = new ConcurrentDictionary<int, long>();
 
+            public void UpdateCreationKnownOffset(IDictionary<int, long> keyValuePairs)
+            {
+                var lastKnownPartitions = keyValuePairs.Keys.ToList();
+
+                foreach (var kv in keyValuePairs)
+                {
+                    if (CreationKnownOffset.ContainsKey(kv.Key))
+                    {
+                        CreationKnownOffset[kv.Key] = kv.Value;
+                    }
+                    else
+                    {
+                        CreationKnownOffset.Add(kv);
+                    }
+                    lastKnownPartitions.Remove(kv.Key);
+                }
+                if (lastKnownPartitions.Count != 0) // if old stored partition are no more managed...
+                {
+                    foreach (var item in lastKnownPartitions)
+                    {
+                        CreationKnownOffset.Remove(item);  // ...then remove them
+                    }
+                }
+            }
+
             public bool IsSynchronized()
             {
                 bool[] bools = new bool[CreationKnownOffset.Count];
@@ -123,7 +148,7 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
         private TTopology _topology;
         private TStream _streams;
 
-        IUpdateAdapter _updateAdapter;
+        readonly IUpdateAdapter _updateAdapter;
 
         private KEFCoreStreamsUncaughtExceptionHandler<StreamsManager<TStream, TStreamBuilder, TTopology, TStoreSupplier, TTimestampExtractor, TConsumed, TMaterialized, TGlobalKTable, TKTable>> _errorHandler;
         private KEFCoreStreamsStateListener<StreamsManager<TStream, TStreamBuilder, TTopology, TStoreSupplier, TTimestampExtractor, TConsumed, TMaterialized, TGlobalKTable, TKTable>> _stateListener;
@@ -210,8 +235,7 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
         public required Func<TTopology, StreamsConfigBuilder, TStream> CreateStreams { get; set; }
         public required Action<TStream,
                                KEFCoreStreamsUncaughtExceptionHandler<StreamsManager<TStream, TStreamBuilder, TTopology, TStoreSupplier, TTimestampExtractor, TConsumed, TMaterialized, TGlobalKTable, TKTable>>,
-                               KEFCoreStreamsStateListener<StreamsManager<TStream, TStreamBuilder, TTopology, TStoreSupplier, TTimestampExtractor, TConsumed, TMaterialized, TGlobalKTable, TKTable>>> SetHandlers
-        { get; set; }
+                               KEFCoreStreamsStateListener<StreamsManager<TStream, TStreamBuilder, TTopology, TStoreSupplier, TTimestampExtractor, TConsumed, TMaterialized, TGlobalKTable, TKTable>>> SetHandlers { get; set; }
         public required Action<TStream> Start { get; set; }
         public required Action<TStream> Pause { get; set; }
         public required Action<TStream> Resume { get; set; }
@@ -438,9 +462,12 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
             if (_managedEntities.TryGetValue(entity, out var innerEntity) &&
                 _storagesForEntities.TryGetValue(innerEntity, out var storage))
             {
-                return EnsureSynchronized(storage, timeout, watch);
+                var currentKnownOffsets = _kafkaCluster.LatestOffsetForEntity(entity);
+                storage.UpdateCreationKnownOffset(currentKnownOffsets);
+                return EnsureSynchronized(storage, timeout, watch) // received data are aligned
+                       && _dataFromStream.IsEmpty; // and all data are processed
             }
-            throw new InvalidOperationException($"{entity} not found");
+            else throw new InvalidOperationException($"{entity} not found in managed entities.");
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool EnsureSynchronized(StreamsAssociatedData storage, long timeout, Stopwatch watcher = null)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add UpdateCreationKnownOffset to update/add/remove partition offsets in CreationKnownOffset. Fetch latest known offsets from the Kafka cluster and update storage before running synchronization checks, and require that in-flight stream data is empty as part of the sync result. Make _updateAdapter readonly, tweak SetHandlers formatting and improve the managed-entity not-found exception message.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
closed #447 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
