### PR TITLE
Refactor internal object creation

### DIFF
--- a/src/net/KEFCore.SerDes.Avro/AvroValueContainer.cs
+++ b/src/net/KEFCore.SerDes.Avro/AvroValueContainer.cs
@@ -47,7 +47,7 @@ public partial class AvroValueContainer<TKey> : AvroValueContainer, IValueContai
     /// <param name="complexPropertyValues">The indexed data, built from EFCore, to be stored in the <see cref="AvroValueContainer{TKey}"/> associated to <paramref name="complexProperties"/></param>
     /// <param name="complexTypeFactory">The instance of <see cref="IComplexTypeConverterFactory"/> will manage strong type conversion</param>
     /// <remarks>This constructor is mandatory and it is used from KEFCore to request a <see cref="AvroValueContainer{TKey}"/></remarks>
-    public AvroValueContainer(IEntityType tName, IProperty[]? properties, object[] propertyValues, IComplexProperty[]? complexProperties = null, object[]? complexPropertyValues = null, IComplexTypeConverterFactory? complexTypeFactory = null)
+    public AvroValueContainer(IEntityType tName, IProperty[]? properties, object?[] propertyValues, IComplexProperty[]? complexProperties = null, object?[]? complexPropertyValues = null, IComplexTypeConverterFactory? complexTypeFactory = null)
     {
         properties ??= [.. tName.GetProperties()];
         EntityName = tName.Name;

--- a/src/net/KEFCore.SerDes.Protobuf/Storage/ProtobufValueContainer.cs
+++ b/src/net/KEFCore.SerDes.Protobuf/Storage/ProtobufValueContainer.cs
@@ -58,7 +58,7 @@ public class ProtobufValueContainer<TKey> : IMessage<ProtobufValueContainer<TKey
     /// <param name="complexPropertyValues">The indexed data, built from EFCore, to be stored in the <see cref="ProtobufValueContainer{TKey}"/> associated to <paramref name="complexProperties"/></param>
     /// <param name="complexTypeFactory">The instance of <see cref="IComplexTypeConverterFactory"/> will manage strong type conversion</param>
     /// <remarks>This constructor is mandatory and it is used from KEFCore to request a <see cref="ProtobufValueContainer{TKey}"/></remarks>
-    public ProtobufValueContainer(IEntityType tName, IProperty[]? properties, object[] propertyValues, IComplexProperty[]? complexProperties = null, object[]? complexPropertyValues = null, IComplexTypeConverterFactory? complexTypeFactory = null)
+    public ProtobufValueContainer(IEntityType tName, IProperty[]? properties, object?[] propertyValues, IComplexProperty[]? complexProperties = null, object?[]? complexPropertyValues = null, IComplexTypeConverterFactory? complexTypeFactory = null)
     {
         properties ??= [.. tName.GetProperties()];
         _innerMessage = new ValueContainer

--- a/src/net/KEFCore.SerDes/DefaultValueContainer.cs
+++ b/src/net/KEFCore.SerDes/DefaultValueContainer.cs
@@ -215,7 +215,7 @@ public class DefaultValueContainer<TKey> : IValueContainer<TKey> where TKey : no
     /// <param name="complexPropertyValues">The indexed data, built from EFCore, to be stored in the <see cref="DefaultValueContainer{TKey}"/> associated to <paramref name="complexProperties"/></param>
     /// <param name="complexTypeFactory">The instance of <see cref="IComplexTypeConverterFactory"/> will manage strong type conversion</param>
     /// <remarks>This constructor is mandatory and it is used from KEFCore to request a <see cref="DefaultValueContainer{TKey}"/></remarks>
-    public DefaultValueContainer(IEntityType tName, IProperty[]? properties, object[] propertyValues, IComplexProperty[]? complexProperties = null, object[]? complexPropertyValues = null, IComplexTypeConverterFactory? complexTypeFactory = null)
+    public DefaultValueContainer(IEntityType tName, IProperty[]? properties, object?[] propertyValues, IComplexProperty[]? complexProperties = null, object?[]? complexPropertyValues = null, IComplexTypeConverterFactory? complexTypeFactory = null)
     {
         properties ??= [.. tName.GetProperties()];
         EntityName = tName.Name;

--- a/src/net/KEFCore/Storage/Internal/EntityTypeProducer.cs
+++ b/src/net/KEFCore/Storage/Internal/EntityTypeProducer.cs
@@ -41,7 +41,7 @@ public class EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContain
 {
     private static IStreamsManager? _streamsManager;
 
-    private readonly ConstructorInfo TValueContainerConstructor;
+    private readonly Func<IEntityType, IProperty[]?, object?[], IComplexProperty[]?, object?[]?, IComplexTypeConverterFactory?, TValueContainer> _createValueContainer;
     private readonly bool _useCompactedReplicator;
     private readonly IKafkaCluster _cluster;
     private readonly IEntityType _entityType;
@@ -210,7 +210,18 @@ public class EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContain
         _useCompactedReplicator = _cluster.Options.UseCompactedReplicator;
 
         var tTValueContainer = typeof(TValueContainer);
-        TValueContainerConstructor = tTValueContainer.GetConstructors().Single(ci => ci.GetParameters().Length == 6);
+        var ctor = tTValueContainer.GetConstructors().Single(ci => ci.GetParameters().Length == 6);
+        var param1 = Expression.Parameter(typeof(IEntityType));
+        var param2 = Expression.Parameter(typeof(IProperty[]));
+        var param3 = Expression.Parameter(typeof(object?[]));
+        var param4 = Expression.Parameter(typeof(IComplexProperty[]));
+        var param5 = Expression.Parameter(typeof(object?[]));
+        var param6 = Expression.Parameter(typeof(IComplexTypeConverterFactory));
+
+        _createValueContainer = Expression.Lambda<Func<IEntityType, IProperty[]?, object?[], IComplexProperty[]?, object?[]?, IComplexTypeConverterFactory?, TValueContainer>>(
+                                           Expression.New(ctor, param1, param2, param3, param4, param5, param6),
+                                           param1, param2, param3, param4, param5, param6)
+                                .Compile();
 
         var keySelector = _cluster.Options.SerDesSelectorForKey(_entityType) as ISerDesSelector<TKey>;
         var valueSelector = _cluster.Options.SerDesSelectorForValue(_entityType) as ISerDesSelector<TValueContainer>;
@@ -343,10 +354,10 @@ public class EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContain
     {
         if (_useCompactedReplicator)
         {
-            foreach (KafkaRowBag<TKey, TValueContainer> record in records.Cast<KafkaRowBag<TKey, TValueContainer>>())
+            foreach (var record in records)
             {
-                var value = record.Value(TValueContainerConstructor, _complexTypeConverterFactory);
-                _kafkaCompactedReplicator?[record.Key] = value!;
+                var value = record.GetValue<TKey, TValueContainer>(_createValueContainer, _complexTypeConverterFactory);
+                _kafkaCompactedReplicator?[record.GetKey<TKey>()] = value!;
             }
 
             return null!;
@@ -354,7 +365,7 @@ public class EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContain
         else
         {
             System.Collections.Generic.List<Future<RecordMetadata>> futures = new();
-            foreach (KafkaRowBag<TKey, TValueContainer> record in records.Cast<KafkaRowBag<TKey, TValueContainer>>())
+            foreach (var record in records)
             {
                 Future<RecordMetadata> future;
 #if OLD_WAY
@@ -364,7 +375,7 @@ public class EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContain
 #else
                 if (record.EntityState == EntityState.Deleted)
                 {
-                    future = _kafkaProducer?.Send(record.AssociatedTopicName, record.Key, null!)!;
+                    future = _kafkaProducer?.Send(record.AssociatedTopicName, record.GetKey<TKey>(), null!)!;
                     futures.Add(future);
                 }
                 else
@@ -374,7 +385,7 @@ public class EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContain
                     {
                         headers = Org.Apache.Kafka.Common.Header.Headers.Create();
                     }
-                    future = _kafkaProducer?.Send(record.AssociatedTopicName, null, record.Key, record.Value(TValueContainerConstructor, _complexTypeConverterFactory)!, headers)!;
+                    future = _kafkaProducer?.Send(record.AssociatedTopicName, null, record.GetKey<TKey>(), record.GetValue<TKey, TValueContainer>(_createValueContainer, _complexTypeConverterFactory)!, headers)!;
                     if (future != null) futures.Add(future);
                 }
 #endif

--- a/src/net/KEFCore/Storage/Internal/IKafkaRowBag.cs
+++ b/src/net/KEFCore/Storage/Internal/IKafkaRowBag.cs
@@ -18,6 +18,8 @@
 
 #nullable enable
 
+using MASES.EntityFrameworkCore.KNet.Serialization;
+
 namespace MASES.EntityFrameworkCore.KNet.Storage.Internal;
 /// <summary>
 ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -47,4 +49,17 @@ public interface IKafkaRowBag
     /// The topic data will be stored
     /// </summary>
     string AssociatedTopicName { get; }
+    /// <summary>
+    /// The key associated to the current <see cref="IKafkaRowBag"/>
+    /// </summary>
+    /// <typeparam name="TKey">The key type</typeparam>
+    public TKey GetKey<TKey>() where TKey : notnull;
+    /// <summary>
+    /// The value associated to the current <see cref="IKafkaRowBag"/>
+    /// </summary>
+    /// <typeparam name="TKey">The key type</typeparam>
+    /// <typeparam name="TValueContainer">The <see cref="IValueContainer{T}"/> containing the converted data</typeparam>
+    TValueContainer? GetValue<TKey, TValueContainer>(Func<IEntityType, IProperty[]?, object?[], IComplexProperty[]?, object?[]?, IComplexTypeConverterFactory?, TValueContainer> creator, IComplexTypeConverterFactory complexTypeConverterFactory)
+        where TKey : notnull
+        where TValueContainer : IValueContainer<TKey>;
 }

--- a/src/net/KEFCore/Storage/Internal/KafkaRowBag.cs
+++ b/src/net/KEFCore/Storage/Internal/KafkaRowBag.cs
@@ -30,12 +30,13 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal;
 /// <remarks>
 /// Default initializer
 /// </remarks>
-public class KafkaRowBag<TKey, TValueContainer>(IUpdateEntry entry, string topicName, TKey key,
-                                                IProperty[] properties, object?[]? propertyValues,
-                                                IComplexProperty[]? complexProperties, object?[]? complexPropertyValues) : IKafkaRowBag
+public class KafkaRowBag<TKey>(IUpdateEntry entry, string topicName, TKey key,
+                               IProperty[] properties, object?[]? propertyValues,
+                               IComplexProperty[]? complexProperties, object?[]? complexPropertyValues) : IKafkaRowBag
     where TKey : notnull
-    where TValueContainer : IValueContainer<TKey>
 {
+    readonly TKey _key = key;
+
     /// <summary>
     /// The <see cref="IEntityType"/> with changes
     /// </summary>
@@ -57,16 +58,18 @@ public class KafkaRowBag<TKey, TValueContainer>(IUpdateEntry entry, string topic
     /// <summary>
     /// The Key
     /// </summary>
-    public TKey Key { get; } = key;
+    public TKeyLocal GetKey<TKeyLocal>() where TKeyLocal : notnull => (TKeyLocal)(object)_key;
     /// <summary>
     /// The Value
     /// </summary>
-    public TValueContainer? Value(ConstructorInfo ci, IComplexTypeConverterFactory complexTypeConverterFactory) 
-        => EntityState == EntityState.Deleted ? default : (TValueContainer)ci.Invoke([EntityType, Properties, PropertyValues, ComplexProperties, ComplexPropertyValues, complexTypeConverterFactory]);
+    public TValueContainer? GetValue<TKeyLocal, TValueContainer>(Func<IEntityType, IProperty[]?, object?[], IComplexProperty[]?, object?[]?, IComplexTypeConverterFactory?, TValueContainer> creator, IComplexTypeConverterFactory complexTypeConverterFactory)
+        where TKeyLocal : notnull
+        where TValueContainer : IValueContainer<TKeyLocal>
+        => EntityState == EntityState.Deleted ? default : (TValueContainer)creator(EntityType, Properties, PropertyValues, ComplexProperties, ComplexPropertyValues, complexTypeConverterFactory);
     /// <summary>
     /// The <see cref="ValueBuffer"/> containing all indexed values of the <see cref="Properties"/>
     /// </summary>
-    public object?[]? PropertyValues { get; } = propertyValues;
+    public object?[] PropertyValues { get; } = propertyValues!;
     /// <summary>
     /// The <see cref="ValueBuffer"/> containing all indexed values of the <see cref="ComplexProperties"/>
     /// </summary>

--- a/src/net/KEFCore/Storage/Internal/KafkaTable.cs
+++ b/src/net/KEFCore/Storage/Internal/KafkaTable.cs
@@ -51,6 +51,8 @@ public class KafkaTable<TKey, TValueContainer, TJVMKey, TJVMValueContainer> : IK
     private readonly ConcurrentDictionary<IEntityType, IProperty[]> _propertiesCache = new();
     private readonly ConcurrentDictionary<IEntityType, IComplexProperty[]> _complexPropertiesCache = new();
 
+    readonly Func<IUpdateEntry, string, TKey, IProperty[], object?[]?, IComplexProperty[]?, object?[]?, IKafkaRowBag> _createRowBag;
+
     //private readonly IProperty[] _properties;
     //private readonly IComplexProperty[]? _complexProperties;
     /// <summary>
@@ -64,6 +66,7 @@ public class KafkaTable<TKey, TValueContainer, TJVMKey, TJVMValueContainer> : IK
 #if DEBUG_PERFORMANCE
 		KNet.Internal.DebugPerformanceHelper.ReportString($"KafkaTable Creating new KafkaTable for {entityType.Name}");
 #endif
+        Cluster = cluster;
         _tableAssociatedTopicName = cluster.CreateTopicForEntity(entityType);
         _producer = (IEntityTypeProducer<TKey>)EntityTypeProducers.Create<TKey, TValueContainer, TJVMKey, TJVMValueContainer>(entityType, cluster);
         _primaryKey = entityType.FindPrimaryKey();
@@ -88,6 +91,20 @@ public class KafkaTable<TKey, TValueContainer, TJVMKey, TJVMValueContainer> : IK
                 _valueComparers.Add((property.GetIndex(), comparer));
             }
         }
+
+        var ctor = typeof(KafkaRowBag<TKey>).GetConstructors().First(); // ([typeof(IUpdateEntry), typeof(string), typeof(TKey), typeof(IProperty[]), typeof(object?[]), typeof(IComplexProperty[]), typeof(object?[])])!;
+        var param1 = Expression.Parameter(typeof(IUpdateEntry));
+        var param2 = Expression.Parameter(typeof(string));
+        var param3 = Expression.Parameter(typeof(TKey));
+        var param4 = Expression.Parameter(typeof(IProperty[]));
+        var param5 = Expression.Parameter(typeof(object?[]));
+        var param6 = Expression.Parameter(typeof(IComplexProperty[]));
+        var param7 = Expression.Parameter(typeof(object?[]));
+
+        _createRowBag = Expression.Lambda<Func<IUpdateEntry, string, TKey, IProperty[], object?[]?, IComplexProperty[]?, object?[]?, IKafkaRowBag>>(
+                                   Expression.New(ctor, param1, param2, param3, param4, param5, param6, param7),
+                                    param1, param2, param3, param4, param5, param6, param7)
+                        .Compile();
     }
     /// <inheritdoc/>
     public virtual void Dispose()
@@ -154,7 +171,7 @@ public class KafkaTable<TKey, TValueContainer, TJVMKey, TJVMValueContainer> : IK
                     complexPropertyValues![index] = entry.GetCurrentValue(complexProperties[index]);
                 }
             }
-            return new KafkaRowBag<TKey, TValueContainer>(entry, _tableAssociatedTopicName, key, properties, propertyValues, complexProperties, complexPropertyValues);
+            return _createRowBag(entry, _tableAssociatedTopicName, key, properties, propertyValues, complexProperties, complexPropertyValues);
         }
     }
     /// <inheritdoc/>
@@ -181,7 +198,7 @@ public class KafkaTable<TKey, TValueContainer, TJVMKey, TJVMValueContainer> : IK
                 ThrowUpdateConcurrencyException(entry, concurrencyConflicts);
             }
 
-            return new KafkaRowBag<TKey, TValueContainer>(entry, _tableAssociatedTopicName, key, properties, null, complexProperties, null);
+            return _createRowBag(entry, _tableAssociatedTopicName, key, properties, null, complexProperties, null);
         }
     }
 
@@ -269,7 +286,7 @@ public class KafkaTable<TKey, TValueContainer, TJVMKey, TJVMValueContainer> : IK
                 }
             }
 
-            return new KafkaRowBag<TKey, TValueContainer>(entry, _tableAssociatedTopicName, key, properties, propertyValues, complexProperties, complexPropertyValues);
+            return _createRowBag(entry, _tableAssociatedTopicName, key, properties, propertyValues, complexProperties, complexPropertyValues);
         }
     }
     /// <inheritdoc/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Make property value parameters nullable (object?[]) in Avro/Protobuf/Default value containers and propagate nullability across related APIs. Replace reflection ConstructorInfo invocations with compiled Expression-based factories for creating TValueContainer and IKafkaRowBag instances in EntityTypeProducer and KafkaTable to reduce reflection overhead and simplify generics. Update IKafkaRowBag and KafkaRowBag to expose typed GetKey/GetValue methods and adapt callers accordingly. Also add minor ownership/field adjustments to align with the new factory-based construction.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
close #455 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
