### PR TITLE
Use indexed loops and remove unused using

### DIFF
--- a/src/net/KEFCore.SerDes.Avro/AvroValueContainer.cs
+++ b/src/net/KEFCore.SerDes.Avro/AvroValueContainer.cs
@@ -53,34 +53,34 @@ public partial class AvroValueContainer<TKey> : AvroValueContainer, IValueContai
         EntityName = tName.Name;
         ClrType = tName.ClrType?.ToAssemblyQualified()!;
         Data = [];
-        foreach (var item in properties)
+        for (int i = 0; i < properties.Length; i++)
         {
-            int index = item.GetIndex();
+            var item = properties[i];
             (NativeTypeMapper.ManagedTypes, bool) _type = NativeTypeMapper.GetValue(item.ClrType!);
-            BuildPropertyValue(item, _type.Item1, _type.Item2, ref propertyValues[index]!);
+            BuildPropertyValue(item, _type.Item1, _type.Item2, ref propertyValues[i]!);
             var pRecord = new PropertyDataRecord
             {
                 ManagedType = (int)_type.Item1,
                 SupportNull = _type.Item2,
-                PropertyName = item.Name,
+                PropertyName = properties[i].Name,
                 ClrType = _type.Item1 == NativeTypeMapper.ManagedTypes.Undefined ? item.ClrType?.ToAssemblyQualified() : null,
-                Value = propertyValues[index]
+                Value = propertyValues[i]
             };
             Data.Add(pRecord);
         }
         if (complexProperties != null && complexPropertyValues != null)
         {
-            foreach (var item in complexProperties)
+            for (int i = 0; i < complexProperties.Length; i++)
             {
-                int index = item.GetIndex();
-                BuildPropertyValue(item, NativeTypeMapper.ManagedTypes.ComplexType, false, ref complexPropertyValues[index]!, complexTypeFactory);
+                var item = complexProperties[i];
+                BuildPropertyValue(item, NativeTypeMapper.ManagedTypes.ComplexType, false, ref complexPropertyValues[i]!, complexTypeFactory);
                 var pRecord = new PropertyDataRecord
                 {
                     ManagedType = (int)NativeTypeMapper.ManagedTypes.ComplexType,
                     SupportNull = false,
                     PropertyName = item.Name,
                     ClrType = item.ClrType?.ToAssemblyQualified(),
-                    Value = complexPropertyValues[index]
+                    Value = complexPropertyValues[i]
                 };
                 Data.Add(pRecord);
             }

--- a/src/net/KEFCore.SerDes.Protobuf/Storage/ProtobufValueContainer.cs
+++ b/src/net/KEFCore.SerDes.Protobuf/Storage/ProtobufValueContainer.cs
@@ -67,28 +67,28 @@ public class ProtobufValueContainer<TKey> : IMessage<ProtobufValueContainer<TKey
             ClrType = tName.ClrType?.ToAssemblyQualified()!
         };
         _innerMessage.Data.Clear();
-        foreach (var item in properties)
+        for (int i = 0; i < properties.Length; i++)
         {
-            int index = item.GetIndex();
+            var item = properties[i];
             var _type = NativeTypeMapper.GetValue(item.ClrType!);
             var pRecord = new PropertyDataRecord
             {
                 PropertyName = item.Name,
                 ClrType = _type.Item1 == NativeTypeMapper.ManagedTypes.Undefined ? item.ClrType?.ToAssemblyQualified() : string.Empty,
-                Value = new GenericValue(_type, ref propertyValues[index]!)
+                Value = new GenericValue(_type, ref propertyValues[i]!)
             };
             _innerMessage.Data.Add(pRecord);
         }
         if (complexProperties != null && complexPropertyValues != null)
         {
-            foreach (var item in complexProperties)
+            for (int i = 0; i < complexProperties.Length; i++)
             {
-                int index = item.GetIndex();
+                var item = complexProperties[i];
                 var pRecord = new PropertyDataRecord
                 {
                     PropertyName = item.Name,
                     ClrType = item.ClrType?.ToAssemblyQualified(),
-                    Value = new GenericValue((NativeTypeMapper.ManagedTypes.ComplexType, false), ref complexPropertyValues[index]!, item, complexTypeFactory)
+                    Value = new GenericValue((NativeTypeMapper.ManagedTypes.ComplexType, false), ref complexPropertyValues[i]!, item, complexTypeFactory)
                 };
                 _innerMessage.Data.Add(pRecord);
             }

--- a/src/net/KEFCore.SerDes/DefaultValueContainer.cs
+++ b/src/net/KEFCore.SerDes/DefaultValueContainer.cs
@@ -20,7 +20,6 @@
 
 #nullable enable
 
-using MASES.JCOBridge.C2JBridge;
 using MASES.KNet.Serialization;
 using System.Text.Json;
 using System.Text.Json.Serialization;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Replace foreach iterations with indexed for loops in AvroValueContainer and ProtobufValueContainer to iterate arrays by index, bind item = properties[i] / complexProperties[i], and consistently access propertyValues[i] and complexPropertyValues[i]. This ensures correct mapping between property descriptors and their value slots and avoids relying on item.GetIndex(). Also remove an unused using (MASES.JCOBridge.C2JBridge) from DefaultValueContainer.cs.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
closed #469 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
