### PR TITLE
Use nameof for GetEntity method lookup

### DIFF
--- a/src/net/KEFCore.SerDes/KEFCoreSerDes.Helpers.cs
+++ b/src/net/KEFCore.SerDes/KEFCoreSerDes.Helpers.cs
@@ -472,7 +472,7 @@ namespace MASES.EntityFrameworkCore.KNet.Serialization
 
             var ccType = typeof(LocalEntityExtractor<,,,,,>);
             var extractorType = ccType.MakeGenericType(keyType, fullValueContainer, typeof(byte[]), typeof(byte[]), fullKeySerializer, fullValueContainerSerializer);
-            var methodInfo = extractorType.GetMethod("GetEntity");
+            var methodInfo = extractorType.GetMethod(nameof(LocalEntityExtractor<,,,,,>.GetEntity));
             var extractor = Activator.CreateInstance(extractorType);
             return methodInfo?.Invoke(extractor, new object[] { topic, recordKey, recordValue, throwUnmatch })!;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Replace the literal "GetEntity" with nameof(LocalEntityExtractor<,,,,,>.GetEntity) in KEFCoreSerDes.Helpers.cs to make the reflection lookup resilient to refactoring/renames. This is a no-behavior-change cleanup that improves maintainability.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
