### PR TITLE
Add ResetStreams API and refactor topic handling to avoid Apache Kafka Streams reset when persistent storage is in use

### DIFF
--- a/src/net/KEFCore/Infrastructure/KafkaDbContext.cs
+++ b/src/net/KEFCore/Infrastructure/KafkaDbContext.cs
@@ -259,6 +259,24 @@ public class KafkaDbContext : DbContext
         return database.EnsureDatabaseSynchronized(waitTimeMs);
     }
 
+    /// <summary>
+    /// Resets the Apache Kafka streams application in use
+    /// </summary>
+    /// <remarks>Use this method with cautions</remarks>
+    public void ResetStreams()
+    {
+        var serviceProvider = ((IInfrastructure<IServiceProvider>)this).Instance;
+        var clusterCache = serviceProvider.GetService<IKafkaClusterCache>();
+        var options = serviceProvider.GetService<IDbContextOptions>();
+
+        if (clusterCache == null) throw new InvalidOperationException($"Unable to retrieve {nameof(IKafkaClusterCache)} service");
+        if (options == null) throw new InvalidOperationException($"Unable to retrieve {nameof(IDbContextOptions)} service");
+
+        var cluster = clusterCache.GetCluster(options);
+
+        cluster?.ResetStreams();
+    }
+
     /// <inheritdoc cref="DbContext.OnConfiguring(DbContextOptionsBuilder)"/>
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {

--- a/src/net/KEFCore/Storage/Internal/IKafkaCluster.cs
+++ b/src/net/KEFCore/Storage/Internal/IKafkaCluster.cs
@@ -58,6 +58,10 @@ public interface IKafkaCluster : IDisposable
     /// </summary>
     IComplexTypeConverterFactory ComplexTypeConverterFactory { get; }
     /// <summary>
+    /// Resets the Apache Kafka streams application associated to this <see cref="IKafkaCluster"/> instance
+    /// </summary>
+    void ResetStreams();
+    /// <summary>
     /// Execute the <see cref="IKafkaDatabase.EnsureDatabaseDeleted"/>
     /// </summary>
     bool EnsureDeleted(IDiagnosticsLogger<DbLoggerCategory.Update> updateLogger);

--- a/src/net/KEFCore/Storage/Internal/KafkaCluster.cs
+++ b/src/net/KEFCore/Storage/Internal/KafkaCluster.cs
@@ -115,9 +115,9 @@ public class KafkaCluster : IKafkaCluster
     /// <inheritdoc/>
     public virtual IComplexTypeConverterFactory ComplexTypeConverterFactory => _complexTypeConverterFactory;
 
-    ArrayList<Java.Lang.String> ResetStream(out System.Collections.Generic.IList<string> topics)
+    ArrayList<Java.Lang.String> TopicsFromModel(out System.Collections.Generic.IList<string> topics)
     {
-        _infrastructureLogger.Logger.LogDebug("Invoking ResetStream");
+        _infrastructureLogger.Logger.LogDebug("Invoking TopicsFromModel");
 
         var coll = new ArrayList<Java.Lang.String>();
         topics = new System.Collections.Generic.List<string>();
@@ -136,7 +136,14 @@ public class KafkaCluster : IKafkaCluster
             coll.Add(topic);
         }
 
-        _infrastructureLogger.Logger.LogInformation("Identfied for model {Model} the following topics {Topics}", _designModel, string.Join(", ", topics));
+        _infrastructureLogger.Logger.LogDebug("Identified from model {Model} the following topics {Topics}", _designModel, string.Join(", ", topics));
+
+        return coll;
+    }
+
+    void ResetStream(System.Collections.Generic.IList<string> topics)
+    {
+        _infrastructureLogger.Logger.LogDebug("Invoking ResetStream");
 
         if (!Options.UseCompactedReplicator)
         {
@@ -151,15 +158,21 @@ public class KafkaCluster : IKafkaCluster
                 throw;
             }
         }
+    }
 
-        return coll;
+    /// <inheritdoc/>
+    public void ResetStreams()
+    {
+        _ = TopicsFromModel(out var topics);
+        ResetStream(topics);
     }
 
     /// <inheritdoc/>
     public virtual bool EnsureDeleted(IDiagnosticsLogger<DbLoggerCategory.Update> updateLogger)
     {
         _infrastructureLogger.Logger.LogDebug("Invoking EnsureDeleted");
-        var coll = ResetStream(out var topics);
+        var coll = TopicsFromModel(out var topics);
+        ResetStream(topics);
 
         try
         {
@@ -196,7 +209,11 @@ public class KafkaCluster : IKafkaCluster
     public virtual bool EnsureCreated(IDiagnosticsLogger<DbLoggerCategory.Update> updateLogger)
     {
         _infrastructureLogger.Logger.LogDebug("Invoking EnsureCreated");
-        var coll = ResetStream(out var topics);
+        var coll = TopicsFromModel(out var topics);
+        if (!Options.UsePersistentStorage)
+        {
+            ResetStream(topics);
+        }
 
         try
         {
@@ -492,16 +509,16 @@ public class KafkaCluster : IKafkaCluster
         {
             tableSw.Start();
 #endif
-            EnsureTable(entityType);
+        EnsureTable(entityType);
 #if DEBUG_PERFORMANCE
             valueBufferSw.Start();
 #endif
-            var key = _useNameMatching ? (object)entityType.Name : entityType;
-            if (_tables != null && _tables.TryGetValue(key, out var table))
-            {
-                return table.ValueBuffers;
-            }
-            throw new InvalidOperationException("No table available");
+        var key = _useNameMatching ? (object)entityType.Name : entityType;
+        if (_tables != null && _tables.TryGetValue(key, out var table))
+        {
+            return table.ValueBuffers;
+        }
+        throw new InvalidOperationException("No table available");
 #if DEBUG_PERFORMANCE
         }
         finally


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Expose a ResetStreams method on KafkaDbContext and IKafkaCluster to allow resetting the Kafka Streams application (DbContext.ResetStreams throws if required services are missing). Refactor KafkaCluster internals by splitting topic extraction (TopicsFromModel) from the reset operation (ResetStream(IList<string>)), adjust logging levels/messages, and update EnsureDeleted/EnsureCreated to use the new flow. Also include minor cleanup/formatting fixes around table/value buffer lookup.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
