### PR TITLE
Use ClusterId for service provider matching

### DIFF
--- a/src/net/KEFCore/Infrastructure/Internal/KafkaOptionsExtension.cs
+++ b/src/net/KEFCore/Infrastructure/Internal/KafkaOptionsExtension.cs
@@ -551,17 +551,19 @@ public class KafkaOptionsExtension : IDbContextOptionsExtension, IKafkaSingleton
     /// <inheritdoc/>
     public void Initialize(IDbContextOptions options)
     {
-        throw new NotImplementedException();
+        var kafkaOptions = options.FindExtension<KafkaOptionsExtension>() ?? throw new InvalidOperationException("Cannot find an instance of KafkaOptionsExtension");
+
+        if (kafkaOptions?.ClusterId != ClusterId)
+        {
+            throw new InvalidOperationException(
+                $"Cannot reuse internal service provider: ClusterId mismatch " +
+                $"(expected '{ClusterId}', got '{kafkaOptions?.ClusterId}')");
+        }
     }
 
-    private sealed class ExtensionInfo : DbContextOptionsExtensionInfo
+    private sealed class ExtensionInfo(IDbContextOptionsExtension extension) : DbContextOptionsExtensionInfo(extension)
     {
         private string? _logFragment;
-
-        public ExtensionInfo(IDbContextOptionsExtension extension)
-            : base(extension)
-        {
-        }
 
         private new KafkaOptionsExtension Extension
             => (KafkaOptionsExtension)base.Extension;
@@ -577,8 +579,30 @@ public class KafkaOptionsExtension : IDbContextOptionsExtension, IKafkaSingleton
                 {
                     var builder = new System.Text.StringBuilder();
 
-                    builder.Append("DataBaseName=").Append(Extension._topicPrefix).Append(' ');
-
+                    builder.Append("KeySerDesSelectorType=").Append(Extension._keySerDesSelectorType).Append(' ');
+                    builder.Append("ValueSerDesSelectorType=").Append(Extension._valueSerDesSelectorType).Append(' ');
+                    builder.Append("ValueContainerType=").Append(Extension._valueContainerType).Append(' ');
+                    builder.Append("UseNameMatching=").Append(Extension._useNameMatching).Append(' ');
+                    builder.Append("TopicPrefix=").Append(Extension._topicPrefix).Append(' ');
+                    builder.Append("ApplicationId=").Append(Extension._applicationId).Append(' ');
+                    builder.Append("BootstrapServers=").Append(Extension._bootstrapServers).Append(' ');
+                    builder.Append("UseDeletePolicyForTopic=").Append(Extension._useDeletePolicyForTopic).Append(' ');
+                    builder.Append("UseCompactedReplicator=").Append(Extension._useCompactedReplicator).Append(' ');
+                    builder.Append("UseKNetStreams=").Append(Extension._useKNetStreams).Append(' ');
+                    builder.Append("UseGlobalTable=").Append(Extension._useGlobalTable).Append(' ');
+                    builder.Append("UsePersistentStorage=").Append(Extension._usePersistentStorage).Append(' ');
+                    builder.Append("UseEnumeratorWithPrefetch=").Append(Extension._useEnumeratorWithPrefetch).Append(' ');
+                    builder.Append("UseByteBufferDataTransfer=").Append(Extension._useByteBufferDataTransfer).Append(' ');
+                    builder.Append("DefaultNumPartitions=").Append(Extension._defaultNumPartitions).Append(' ');
+                    builder.Append("DefaultReplicationFactor=").Append(Extension._defaultReplicationFactor).Append(' ');
+                    builder.Append("DefaultConsumerInstances=").Append(Extension._defaultConsumerInstances).Append(' ');
+                    builder.Append("ConsumerConfigBuilder=").Append(Extension._consumerConfigBuilder?.ToString()).Append(' ');
+                    builder.Append("ProducerConfigBuilder=").Append(Extension._producerConfigBuilder?.ToString()).Append(' ');
+                    builder.Append("StreamsConfigBuilder=").Append(Extension._streamsConfigBuilder?.ToString()).Append(' ');
+                    builder.Append("TopicConfigBuilder=").Append(Extension._topicConfigBuilder?.ToString()).Append(' ');
+                    builder.Append("ManageEvents=").Append(Extension._manageEvents).Append(' ');
+                    builder.Append("ReadOnlyMode=").Append(Extension._readOnlyMode).Append(' ');
+                    builder.Append("DefaultSynchronizationTimeout=").Append(Extension._defaultSynchronizationTimeout).Append(' ');
                     _logFragment = builder.ToString();
                 }
 
@@ -587,14 +611,14 @@ public class KafkaOptionsExtension : IDbContextOptionsExtension, IKafkaSingleton
         }
 
         public override int GetServiceProviderHashCode()
-            => Extension._bootstrapServers?.GetHashCode() ?? 0;
+            => Extension.ClusterId?.GetHashCode() ?? 0;
 
         public override bool ShouldUseSameServiceProvider(DbContextOptionsExtensionInfo other)
             => other is ExtensionInfo otherInfo
-                && Extension._bootstrapServers == otherInfo.Extension._bootstrapServers;
+                && Extension.ClusterId == otherInfo.Extension.ClusterId;
 
         public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
-            => debugInfo["KafkaDatabase:BootstrapServers"]
-                = (Extension._bootstrapServers?.GetHashCode() ?? 0).ToString(CultureInfo.InvariantCulture);
+            => debugInfo["KafkaDatabase:ClusterId"]
+                = (Extension.ClusterId?.GetHashCode() ?? 0).ToString(CultureInfo.InvariantCulture);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Initialize now validates and compares ClusterId from the provided IDbContextOptionsExtension and throws a clear InvalidOperationException on mismatch. ExtensionInfo was converted to a primary-constructor subclass and its log fragment was expanded to include many Kafka-related option properties (serdes, topic/app ids, bootstrap servers, flags, defaults, config builders, etc.). Service provider identity (hash, equality) and debug info now use ClusterId instead of BootstrapServers. Removed the redundant explicit constructor.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
