### PR TITLE
Add complex-type projection support

### DIFF
--- a/src/net/KEFCore/Query/Internal/EntityProjectionExpression.cs
+++ b/src/net/KEFCore/Query/Internal/EntityProjectionExpression.cs
@@ -29,9 +29,17 @@ namespace MASES.EntityFrameworkCore.KNet.Query.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-public class EntityProjectionExpression : Expression, IPrintableExpression
+/// <remarks>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </remarks>
+public class EntityProjectionExpression(
+    IEntityType entityType,
+    IReadOnlyDictionary<IProperty, MethodCallExpression> readExpressionMap) : Expression, IPrintableExpression
 {
-    private readonly IReadOnlyDictionary<IProperty, MethodCallExpression> _readExpressionMap;
+    private readonly IReadOnlyDictionary<IProperty, MethodCallExpression> _readExpressionMap = readExpressionMap;
     private readonly Dictionary<INavigation, StructuralTypeShaperExpression> _navigationExpressionsCache = new();
 
     /// <summary>
@@ -40,21 +48,7 @@ public class EntityProjectionExpression : Expression, IPrintableExpression
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public EntityProjectionExpression(
-        IEntityType entityType,
-        IReadOnlyDictionary<IProperty, MethodCallExpression> readExpressionMap)
-    {
-        EntityType = entityType;
-        _readExpressionMap = readExpressionMap;
-    }
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public virtual IEntityType EntityType { get; }
+    public virtual IEntityType EntityType { get; } = entityType;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -134,6 +128,24 @@ public class EntityProjectionExpression : Expression, IPrintableExpression
         }
 
         return _readExpressionMap[property];
+    }
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual KafkaComplexTypeProjectionExpression BindComplexProperty(IComplexProperty complexProperty)
+    {
+        if (EntityType != complexProperty.DeclaringType
+            && !EntityType.IsAssignableFrom(complexProperty.DeclaringType as IEntityType))
+        {
+            throw new InvalidOperationException(
+                KafkaStrings.UnableToBindMemberToEntityProjection(
+                    "complexProperty", complexProperty.Name, EntityType.DisplayName()));
+        }
+
+        return new KafkaComplexTypeProjectionExpression(complexProperty, _readExpressionMap);
     }
 
     /// <summary>

--- a/src/net/KEFCore/Query/Internal/KafkaComplexTypeProjectionExpression.cs
+++ b/src/net/KEFCore/Query/Internal/KafkaComplexTypeProjectionExpression.cs
@@ -1,0 +1,87 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+/*
+*  Copyright (c) 2022-2026 MASES s.r.l.
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*  Refer to LICENSE for more information.
+*/
+
+using MASES.EntityFrameworkCore.KNet.Internal;
+
+namespace MASES.EntityFrameworkCore.KNet.Query.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+/// <remarks>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </remarks>
+public class KafkaComplexTypeProjectionExpression(
+    IComplexProperty complexProperty,
+    IReadOnlyDictionary<IProperty, MethodCallExpression> readExpressionMap) : Expression
+{
+    private readonly IReadOnlyDictionary<IProperty, MethodCallExpression> _readExpressionMap = readExpressionMap;
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public IComplexProperty ComplexProperty { get; } = complexProperty;
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public IComplexType ComplexType => ComplexProperty.ComplexType;
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override Type Type => ComplexType.ClrType;
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override ExpressionType NodeType => ExpressionType.Extension;
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public MethodCallExpression BindProperty(IProperty property)
+        => _readExpressionMap[property];
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public KafkaComplexTypeProjectionExpression BindComplexProperty(IComplexProperty complexProperty)
+        => new(complexProperty, _readExpressionMap);
+}

--- a/src/net/KEFCore/Query/Internal/KafkaExpressionTranslatingExpressionVisitor.cs
+++ b/src/net/KEFCore/Query/Internal/KafkaExpressionTranslatingExpressionVisitor.cs
@@ -19,12 +19,12 @@
 *  Refer to LICENSE for more information.
 */
 
+using JetBrains.Annotations;
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.RegularExpressions;
-using JetBrains.Annotations;
 using ExpressionExtensions = Microsoft.EntityFrameworkCore.Infrastructure.ExpressionExtensions;
 
 namespace MASES.EntityFrameworkCore.KNet.Query.Internal;
@@ -1147,6 +1147,13 @@ public class KafkaExpressionTranslatingExpressionVisitor : ExpressionVisitor
         return result;
     }
 
+    private static IEnumerable<IProperty> GetAllPropertiesInHierarchy(IEntityType entityType)
+#if NET8_0
+        => entityType.GetAllBaseTypes().Concat(entityType.GetDerivedTypesInclusive()).SelectMany(t => t.GetFlattenedProperties());
+#else
+        => entityType.GetFlattenedPropertiesInHierarchy();
+#endif
+
     private Expression? TryBindMember(Expression? source, MemberIdentity member, Type type)
     {
         if (source is not StructuralTypeReferenceExpression typeReference)
@@ -1154,15 +1161,24 @@ public class KafkaExpressionTranslatingExpressionVisitor : ExpressionVisitor
             return null;
         }
 
-        var entityType = typeReference.StructuralType;
+        var structuralType = typeReference.StructuralType;
 
-        var property = member.MemberInfo != null
-            ? entityType.FindProperty(member.MemberInfo)
-            : entityType.FindProperty(member.Name!);
+        var regularProperty = member.MemberInfo != null
+            ? structuralType.FindProperty(member.MemberInfo)
+            : structuralType.FindProperty(member.Name!);
 
-        if (property != null)
+        if (regularProperty != null)
         {
-            return BindProperty(typeReference, property, type);
+           return BindProperty(typeReference, regularProperty, type);
+        }
+
+        var complexProperty = member.MemberInfo != null
+            ? structuralType.FindComplexProperty(member.MemberInfo)
+            : structuralType.FindComplexProperty(member.Name!);
+
+        if (complexProperty != null)
+        {
+            return BindComplexProperty(typeReference, complexProperty);
         }
 
         AddTranslationErrorDetails(
@@ -1211,6 +1227,42 @@ public class KafkaExpressionTranslatingExpressionVisitor : ExpressionVisitor
         }
 
         return null;
+    }
+
+    private Expression? BindComplexProperty(
+    StructuralTypeReferenceExpression typeReference,
+    IComplexProperty complexProperty)
+    {
+        KafkaComplexTypeProjectionExpression complexProjection;
+
+        if (typeReference.ComplexProjection != null)
+        {
+            // già dentro un ComplexType — scendi di un livello
+            complexProjection = typeReference.ComplexProjection
+                                             .BindComplexProperty(complexProperty);
+        }
+        else if (typeReference.Parameter != null)
+        {
+            // root entity — stessa logica di BindProperty
+            var valueBufferExpression = Visit(typeReference.Parameter.ValueBufferExpression);
+            if (valueBufferExpression == QueryCompilationContext.NotTranslatedExpression)
+                return null;
+
+            complexProjection = ((EntityProjectionExpression)valueBufferExpression)
+                                    .BindComplexProperty(complexProperty);
+        }
+        else if (typeReference.Subquery != null)
+        {
+            // subquery — non supportato per ComplexType
+            return QueryCompilationContext.NotTranslatedExpression;
+        }
+        else
+        {
+            return null;
+        }
+
+        return new StructuralTypeReferenceExpression(
+            typeReference, complexProperty, complexProjection);
     }
 
     private static Expression ProcessSingleResultScalar(
@@ -1745,9 +1797,22 @@ public class KafkaExpressionTranslatingExpressionVisitor : ExpressionVisitor
             StructuralType = type;
         }
 
+        // NUOVO: costruttore per ComplexType
+        public StructuralTypeReferenceExpression(
+            StructuralTypeReferenceExpression parent,
+            IComplexProperty complexProperty,
+            KafkaComplexTypeProjectionExpression complexProjection)
+        {
+            Parameter = parent.Parameter;
+            Subquery = parent.Subquery;
+            StructuralType = complexProperty.ComplexType;
+            ComplexProjection = complexProjection;
+        }
+
         public new StructuralTypeShaperExpression? Parameter { get; }
         public ShapedQueryExpression? Subquery { get; }
         public ITypeBase StructuralType { get; }
+        public KafkaComplexTypeProjectionExpression? ComplexProjection { get; } // NUOVO
 
         public override Type Type
             => StructuralType.ClrType;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Introduce KafkaComplexTypeProjectionExpression and wire complex-property binding through the translation pipeline. EntityProjectionExpression was updated to use a primary-constructor style and now exposes BindComplexProperty to create complex-type projections. KafkaExpressionTranslatingExpressionVisitor was updated to resolve regular vs complex properties (TryBindMember), added BindComplexProperty, a helper GetAllPropertiesInHierarchy, and extended StructuralTypeReferenceExpression to carry complex projection state.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
