### PR TITLE
Temporary disable cluster access when requesting `ModelBuilder`

### DIFF
--- a/src/net/KEFCore/Metadata/Conventions/KafkaConventionSetBuilder.cs
+++ b/src/net/KEFCore/Metadata/Conventions/KafkaConventionSetBuilder.cs
@@ -19,10 +19,12 @@
 *  Refer to LICENSE for more information.
 */
 
+using MASES.EntityFrameworkCore.KNet.Storage.Internal;
+
 namespace MASES.EntityFrameworkCore.KNet.Metadata.Conventions;
 
 /// <summary>
-///     A builder for building conventions for th Kafka provider.
+///     A builder for building conventions for the KEFCore provider.
 /// </summary>
 /// <remarks>
 ///     <para>
@@ -34,7 +36,7 @@ namespace MASES.EntityFrameworkCore.KNet.Metadata.Conventions;
 ///     </para>
 ///     <para>
 ///         See <see href="https://aka.ms/efcore-docs-conventions">Model building conventions</see>, and
-///         <see href="https://github.com/masesgroup/KEFCore">The EF Core Kafka database provider</see> for more information and examples.
+///         <see href="https://github.com/masesgroup/KEFCore">The EF Core KNet database provider</see> for more information and examples.
 ///     </para>
 /// </remarks>
 /// <remarks>
@@ -54,7 +56,7 @@ public class KafkaConventionSetBuilder(ProviderConventionSetBuilderDependencies 
     }
 
     /// <summary>
-    ///     Call this method to build a <see cref="ConventionSet" /> for the Kafka provider when using
+    ///     Call this method to build a <see cref="ConventionSet" /> for the KEFCore provider when using
     ///     the <see cref="ModelBuilder" /> outside of <see cref="DbContext.OnModelCreating" />.
     /// </summary>
     /// <remarks>
@@ -64,13 +66,19 @@ public class KafkaConventionSetBuilder(ProviderConventionSetBuilderDependencies 
     /// <returns>The convention set.</returns>
     public static ConventionSet Build()
     {
-        using var serviceScope = CreateServiceScope();
-        using var context = serviceScope.ServiceProvider.GetRequiredService<DbContext>();
-        return ConventionSet.CreateConventionSet(context);
+        try
+        {
+            KafkaClusterAdmin.DisableClusterInvocation = true;
+
+            using var serviceScope = CreateServiceScope();
+            using var context = serviceScope.ServiceProvider.GetRequiredService<DbContext>();
+            return ConventionSet.CreateConventionSet(context);
+        }
+        finally { KafkaClusterAdmin.DisableClusterInvocation = false; }
     }
 
     /// <summary>
-    ///     Call this method to build a <see cref="ModelBuilder" /> for SQLite outside of <see cref="DbContext.OnModelCreating" />.
+    ///     Call this method to build a <see cref="ModelBuilder" /> for KEFCore outside of <see cref="DbContext.OnModelCreating" />.
     /// </summary>
     /// <remarks>
     ///     Note that it is unusual to use this method. Consider using <see cref="DbContext" /> in the normal way instead.
@@ -78,9 +86,15 @@ public class KafkaConventionSetBuilder(ProviderConventionSetBuilderDependencies 
     /// <returns>The convention set.</returns>
     public static ModelBuilder CreateModelBuilder()
     {
-        using var serviceScope = CreateServiceScope();
-        using var context = serviceScope.ServiceProvider.GetRequiredService<DbContext>();
-        return new ModelBuilder(ConventionSet.CreateConventionSet(context), context.GetService<ModelDependencies>());
+        try
+        {
+            KafkaClusterAdmin.DisableClusterInvocation = true;
+
+            using var serviceScope = CreateServiceScope();
+            using var context = serviceScope.ServiceProvider.GetRequiredService<DbContext>();
+            return new ModelBuilder(ConventionSet.CreateConventionSet(context), context.GetService<ModelDependencies>());
+        }
+        finally { KafkaClusterAdmin.DisableClusterInvocation = false; }
     }
 
     private static IServiceScope CreateServiceScope()

--- a/src/net/KEFCore/Storage/Internal/KafkaClusterAdmin.cs
+++ b/src/net/KEFCore/Storage/Internal/KafkaClusterAdmin.cs
@@ -26,12 +26,13 @@ using Org.Apache.Kafka.Clients.Admin;
 using Org.Apache.Kafka.Common;
 using Org.Apache.Kafka.Common.Acl;
 using Org.Apache.Kafka.Common.Errors;
-using System.Linq;
 
 namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
 {
     internal class KafkaClusterAdmin : IDisposable
     {
+        static internal bool DisableClusterInvocation = false; // used only to activate an external model builder
+
         readonly string _clusterId;
         private readonly Admin? _kafkaAdminClient = null;
         private readonly Properties _bootstrapProperties;
@@ -43,6 +44,8 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
 
         KafkaClusterAdmin(string bootstrapServers)
         {
+            if (DisableClusterInvocation) { _clusterId = "FakeClusterId"; return; }
+
             _bootstrapProperties = AdminClientConfigBuilder.Create().WithBootstrapServers(bootstrapServers).ToProperties();
             try
             {

--- a/test/KEFCore.Standalone.Model.Test/KEFCore.Standalone.Model.Test.csproj
+++ b/test/KEFCore.Standalone.Model.Test/KEFCore.Standalone.Model.Test.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<Import Project="..\Common\Common.props" />
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<AssemblyName>MASES.EntityFrameworkCore.KNet.Standalone.Model.TestTest</AssemblyName>
+		<RootNamespace>MASES.EntityFrameworkCore.KNet.Standalone.Model.Test</RootNamespace>
+		<Title>EntityFrameworkCore KNet Standalone Model Test</Title>
+		<Description>EntityFrameworkCore KNet Standalone Model Test</Description>
+		<Product>MASES.EntityFrameworkCore.KNet.Standalone.Model.Test</Product>
+		<OutputPath>..\..\bin\</OutputPath>
+	</PropertyGroup>
+	<ItemGroup>
+	  <ProjectReference Include="..\Common\KEFCore.Common.Test.csproj" />
+	</ItemGroup>
+</Project>

--- a/test/KEFCore.Standalone.Model.Test/Program.cs
+++ b/test/KEFCore.Standalone.Model.Test/Program.cs
@@ -1,0 +1,42 @@
+﻿/*
+*  Copyright (c) 2022-2026 MASES s.r.l.
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*  Refer to LICENSE for more information.
+*/
+
+using MASES.EntityFrameworkCore.KNet.Metadata.Conventions;
+using MASES.EntityFrameworkCore.KNet.Test.Common.Model.MultiLevelComplex;
+using System.Linq;
+
+namespace MASES.EntityFrameworkCore.KNet.Standalone.Model.Test
+{
+    partial class Program
+    {
+        static void Main(string[] args)
+        {
+            var builder = KafkaConventionSetBuilder.CreateModelBuilder();
+
+            builder.Entity<BlogComplex>();
+
+            var IModel = builder.FinalizeModel();
+
+            var entity = IModel.FindEntityType(typeof(BlogComplex));
+
+            var flatProp = entity.GetFlattenedProperties().ToArray();
+
+            //var complexProp = entity.GetComplexProperties();
+        }
+    }
+}

--- a/test/KEFCore.Test.sln
+++ b/test/KEFCore.Test.sln
@@ -41,6 +41,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KEFCore.Complex.Reduced.Tes
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KEFCore.MultiLevel.Complex.Test", "KEFCore.MultiLevel.Complex.Test\KEFCore.MultiLevel.Complex.Test.csproj", "{06F28526-9056-44DC-07D8-2EAB8EF88798}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KEFCore.Standalone.Model.Test", "KEFCore.Standalone.Model.Test\KEFCore.Standalone.Model.Test.csproj", "{7D4D5E75-D8D6-C66F-B399-87E17944B555}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -111,6 +113,10 @@ Global
 		{06F28526-9056-44DC-07D8-2EAB8EF88798}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{06F28526-9056-44DC-07D8-2EAB8EF88798}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{06F28526-9056-44DC-07D8-2EAB8EF88798}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7D4D5E75-D8D6-C66F-B399-87E17944B555}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7D4D5E75-D8D6-C66F-B399-87E17944B555}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7D4D5E75-D8D6-C66F-B399-87E17944B555}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7D4D5E75-D8D6-C66F-B399-87E17944B555}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -132,6 +138,7 @@ Global
 		{4B8BF643-F78D-B26D-A7EE-E8685B15D00F} = {4A0AD520-9BC4-4F92-893B-6F92BBC35BFA}
 		{7B0D35D1-6275-B72F-DE16-8B42AACAB1F4} = {4A0AD520-9BC4-4F92-893B-6F92BBC35BFA}
 		{06F28526-9056-44DC-07D8-2EAB8EF88798} = {4A0AD520-9BC4-4F92-893B-6F92BBC35BFA}
+		{7D4D5E75-D8D6-C66F-B399-87E17944B555} = {4A0AD520-9BC4-4F92-893B-6F92BBC35BFA}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {36C294ED-9ECE-42AA-8273-31E008749AF3}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

`KafkaClusterAdmin` temporary avoids creation of cluster communication returning a fake ClusterId giving the opportunity to create a `ModelBuilder` without the need to enable KNet infrastructure. Adds a specific and basic test to verify the expected behavior.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
