### PR TITLE
Introduces the optional RecyclableMemoryStream

### DIFF
--- a/src/net/KEFCore.SerDes.Avro/AvroKEFCoreSerDes.cs
+++ b/src/net/KEFCore.SerDes.Avro/AvroKEFCoreSerDes.cs
@@ -134,7 +134,7 @@ public static class AvroKEFCoreSerDes
 
                     if (data == null) return null!;
 
-                    using MemoryStream memStream = new();
+                    using MemoryStream memStream = RecyclableMemoryStreamSupport.Rent();
                     BinaryEncoder encoder = new(memStream);
                     var container = new AvroKeyContainer();
                     if (data is object[] dataArray)
@@ -156,9 +156,9 @@ public static class AvroKEFCoreSerDes
                     if (_defaultSerDes != null) return _defaultSerDes.DeserializeWithHeaders(topic, headers, data);
                     if (data == null || data.Length == 0) return default!;
 
-                    using MemoryStream memStream = new(data);
+                    using MemoryStream memStream = RecyclableMemoryStreamSupport.Rent();
                     BinaryDecoder decoder = new(memStream);
-                    AvroKeyContainer t = new AvroKeyContainer();
+                    AvroKeyContainer t = new();
                     t = SpecificReader.Read(t!, decoder);
                     return (TData)(object)(t.PrimaryKey.ToArray());
                 }
@@ -208,7 +208,7 @@ public static class AvroKEFCoreSerDes
 
                     if (data == null) return null!;
 
-                    MemoryStream memStream = new();
+                    MemoryStream memStream = RecyclableMemoryStreamSupport.Rent();
                     BinaryEncoder encoder = new(memStream);
                     var container = new AvroKeyContainer();
                     if (data is object[] dataArray)
@@ -321,7 +321,7 @@ public static class AvroKEFCoreSerDes
 
                     if (data == null) return null!;
 
-                    using MemoryStream memStream = new();
+                    using MemoryStream memStream = RecyclableMemoryStreamSupport.Rent();
                     JsonEncoder encoder = new(AvroKeyContainer._SCHEMA, memStream);
                     SpecificWriter.Write(data, encoder);
                     encoder.Flush();
@@ -390,7 +390,7 @@ public static class AvroKEFCoreSerDes
 
                     if (data == null) return null!;
 
-                    MemoryStream memStream = new();
+                    MemoryStream memStream = RecyclableMemoryStreamSupport.Rent();
                     JsonEncoder encoder = new(AvroKeyContainer._SCHEMA, memStream);
                     SpecificWriter.Write(data, encoder);
                     encoder.Flush();
@@ -509,7 +509,7 @@ public static class AvroKEFCoreSerDes
 
                     if (data == null) return null!;
 
-                    using MemoryStream memStream = new();
+                    using MemoryStream memStream = RecyclableMemoryStreamSupport.Rent();
                     BinaryEncoder encoder = new(memStream);
                     SpecificWriter.Write(data, encoder);
                     return memStream.ToArray();
@@ -579,7 +579,7 @@ public static class AvroKEFCoreSerDes
 
                     if (data == null) return null!;
 
-                    MemoryStream memStream = new();
+                    MemoryStream memStream = RecyclableMemoryStreamSupport.Rent();
                     BinaryEncoder encoder = new(memStream);
                     SpecificWriter.Write(data, encoder);
                     return ByteBuffer.From(memStream);
@@ -689,7 +689,7 @@ public static class AvroKEFCoreSerDes
 
                     if (data == null) return null!;
 
-                    using MemoryStream memStream = new();
+                    using MemoryStream memStream = RecyclableMemoryStreamSupport.Rent();
                     JsonEncoder encoder = new(AvroValueContainer._SCHEMA, memStream);
                     SpecificWriter.Write(data, encoder);
                     encoder.Flush();
@@ -760,7 +760,7 @@ public static class AvroKEFCoreSerDes
 
                     if (data == null) return null!;
 
-                    MemoryStream memStream = new();
+                    MemoryStream memStream = RecyclableMemoryStreamSupport.Rent();
                     JsonEncoder encoder = new(AvroValueContainer._SCHEMA, memStream);
                     SpecificWriter.Write(data, encoder);
                     encoder.Flush();

--- a/src/net/KEFCore.SerDes.Protobuf/ProtobufKEFCoreSerDes.cs
+++ b/src/net/KEFCore.SerDes.Protobuf/ProtobufKEFCoreSerDes.cs
@@ -131,7 +131,7 @@ public static class ProtobufKEFCoreSerDes
                     keyContainer = new KeyContainer(dataArray);
                 }
 
-                using MemoryStream stream = new();
+                using MemoryStream stream = RecyclableMemoryStreamSupport.Rent();
                 keyContainer.WriteTo(stream);
                 return stream.ToArray();
             }
@@ -201,7 +201,7 @@ public static class ProtobufKEFCoreSerDes
                     keyContainer = new KeyContainer(dataArray);
                 }
 
-                using MemoryStream stream = new();
+                using MemoryStream stream = RecyclableMemoryStreamSupport.Rent();
                 keyContainer.WriteTo(stream);
                 return stream.ToArray();
             }
@@ -309,7 +309,7 @@ public static class ProtobufKEFCoreSerDes
 
                 if (data == null) return null!;
 
-                using MemoryStream stream = new();
+                using MemoryStream stream = RecyclableMemoryStreamSupport.Rent();
                 data.WriteTo(stream);
                 return stream.ToArray();
             }
@@ -372,7 +372,7 @@ public static class ProtobufKEFCoreSerDes
 
                 if (data == null) return null!;
 
-                MemoryStream stream = new();
+                MemoryStream stream = RecyclableMemoryStreamSupport.Rent();
                 data.WriteTo(stream);
                 return ByteBuffer.From(stream);
             }

--- a/src/net/KEFCore.SerDes/KEFCore.SerDes.csproj
+++ b/src/net/KEFCore.SerDes/KEFCore.SerDes.csproj
@@ -48,5 +48,6 @@
 			<IncludeAssets>All</IncludeAssets>
 			<PrivateAssets>None</PrivateAssets>
 		</PackageReference>
+		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
 	</ItemGroup>
 </Project>

--- a/src/net/KEFCore.SerDes/KEFCoreSerDes.Helpers.cs
+++ b/src/net/KEFCore.SerDes/KEFCoreSerDes.Helpers.cs
@@ -24,12 +24,12 @@ using MASES.EntityFrameworkCore.KNet.Serialization.Json.Storage;
 using MASES.JCOBridge.C2JBridge;
 using MASES.KNet.Consumer;
 using MASES.KNet.Serialization;
+using Microsoft.IO;
 using Org.Apache.Kafka.Clients.Consumer;
 using Org.Apache.Kafka.Common.Serialization;
 using System.Collections.Concurrent;
 using System.Text;
 using System.Text.Json;
-using static MASES.EntityFrameworkCore.KNet.Serialization.Json.DefaultKEFCoreSerDes;
 
 namespace MASES.EntityFrameworkCore.KNet.Internal
 {
@@ -94,15 +94,126 @@ namespace MASES.EntityFrameworkCore.KNet.Internal
 namespace MASES.EntityFrameworkCore.KNet.Serialization
 {
     /// <summary>
+    /// An helper class to centralize management of every <see cref="ByteBuffer"/> conversion for <see cref="MASES.EntityFrameworkCore.KNet.Serialization.Json.DefaultKEFCoreSerDes"/> 
+    /// or any other serialization sub-system which needs <see cref="ByteBuffer"/> transport
+    /// </summary>
+    public static class RecyclableMemoryStreamSupport
+    {
+        static readonly ConcurrentDictionary<string, RecyclableMemoryStream> _storer = new();
+        static RecyclableMemoryStreamManager _manager;
+
+        static bool _enable;
+        static RecyclableMemoryStreamManager.Options _options;
+
+        static long _streamId = 0;
+        static RecyclableMemoryStreamSupport()
+        {
+#if DEBUG
+            _enable = true;
+#endif
+            _options = new RecyclableMemoryStreamManager.Options()
+            {
+                BlockSize = 1024,
+                LargeBufferMultiple = 1024 * 1024,
+                MaximumBufferSize = 16 * 1024 * 1024,
+                GenerateCallStacks = true,
+                AggressiveBufferReturn = true,
+                MaximumLargePoolFreeBytes = 16 * 1024 * 1024 * 4,
+                MaximumSmallPoolFreeBytes = 100 * 1024,
+            };
+
+            _manager = CreateRecyclableMemoryStreamManager(_options);
+        }
+
+        static RecyclableMemoryStreamManager CreateRecyclableMemoryStreamManager(RecyclableMemoryStreamManager.Options options)
+        {
+            var manager = new RecyclableMemoryStreamManager(options);
+            manager.StreamDoubleDisposed += RecyclableMemoryStreamManager_StreamDoubleDisposed;
+            manager.StreamDisposed += RecyclableMemoryStreamManager_StreamDisposed;
+            return manager;
+        }
+
+        static RecyclableMemoryStreamManager ReCreateRecyclableMemoryStreamManager(RecyclableMemoryStreamManager.Options options)
+        {
+            if (_manager != null)
+            {
+                _manager.StreamDoubleDisposed -= RecyclableMemoryStreamManager_StreamDoubleDisposed;
+                _manager.StreamDisposed -= RecyclableMemoryStreamManager_StreamDisposed;
+            }
+            return CreateRecyclableMemoryStreamManager(options);
+        }
+
+        private static void RecyclableMemoryStreamManager_StreamDisposed(object? sender, RecyclableMemoryStreamManager.StreamDisposedEventArgs e)
+        {
+            _storer.TryRemove(e.Tag!, out _);
+        }
+
+        private static void RecyclableMemoryStreamManager_StreamDoubleDisposed(object? sender, RecyclableMemoryStreamManager.StreamDoubleDisposedEventArgs e)
+        {
+#if !DEBUG
+            Console.WriteLine($"Stream {e.Tag} disposed twice.");
+#else
+            Console.WriteLine($"Stream {e.Tag} disposed twice:");
+            Console.WriteLine($"First callstack is {e.DisposeStack1}");
+            Console.WriteLine($"Second callstack is {e.DisposeStack2}");
+            Console.WriteLine($"Originally allocated from {e.AllocationStack}");
+#endif
+        }
+        /// <summary>
+        /// Set to <see langword="true"/> to enable, or <see langword="false"/> to disable, the usage of <see cref="RecyclableMemoryStream"/>
+        /// </summary>
+        /// <param name="enable"><see langword="true"/> to enable <see cref="RecyclableMemoryStream"/> support with optional <paramref name="options"/></param>
+        /// <param name="options">The <see cref="RecyclableMemoryStreamManager.Options"/> options to use</param>
+        public static void SetEnable(bool enable, RecyclableMemoryStreamManager.Options? options = null)
+        {
+            _enable = enable;
+            if (_enable)
+            {
+                _options = options ?? new RecyclableMemoryStreamManager.Options()
+                {
+                    BlockSize = 1024,
+                    LargeBufferMultiple = 1024 * 1024,
+                    MaximumBufferSize = 16 * 1024 * 1024,
+#if DEBUG
+                    GenerateCallStacks = true,
+#endif
+                    AggressiveBufferReturn = true,
+                    MaximumLargePoolFreeBytes = 16 * 1024 * 1024 * 4,
+                    MaximumSmallPoolFreeBytes = 100 * 1024,
+                };
+                lock (_options)
+                {
+                    while (!_storer.IsEmpty) Thread.Sleep(1);                   // wait the queue of current RecyclableMemoryStreamManager is empty, then
+                    _manager = ReCreateRecyclableMemoryStreamManager(_options); // recreate it
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns a new <see cref="MemoryStream"/> which is an implementation  of <see cref="RecyclableMemoryStream"/>
+        /// </summary>
+        /// <returns>The allocated <see cref="MemoryStream"/></returns>
+        public static MemoryStream Rent()
+        {
+            if (!_enable) return new MemoryStream();
+
+            var tag = Interlocked.Increment(ref _streamId).ToString();
+            var stream = _manager.GetStream(tag);
+            _storer.TryAdd(tag, stream);
+            return stream;
+        }
+    }
+
+    /// <summary>
     /// An helper class to centralize management of every Json conversion for <see cref="MASES.EntityFrameworkCore.KNet.Serialization.Json.DefaultKEFCoreSerDes"/> 
-    /// or any other serialization sub-system which needs Jon conversion (typically when there isn't any <see cref="IComplexTypeConverter"/> available in <see cref="IComplexTypeConverterFactory"/> instance)
+    /// or any other serialization sub-system which needs Json conversion (typically when there isn't any <see cref="IComplexTypeConverter"/> available in <see cref="IComplexTypeConverterFactory"/> instance)
     /// </summary>
     public class JsonSupport
     {
         /// <summary>
         /// The <see cref="JsonSerializerOptions"/> used for serialization/deserialization of <see cref="Key{T}"/>
         /// </summary>
-        public static readonly JsonSerializerOptions? DefautJsonOptions = new();
+        public readonly JsonSerializerOptions? DefautJsonOptions = new();
         /// <inheritdoc cref="JsonSerializer.Serialize(object, Type, JsonSerializerOptions?)"/>
         public string Serialize(Type type, object data)
         {
@@ -148,14 +259,14 @@ namespace MASES.EntityFrameworkCore.KNet.Serialization
         /// <inheritdoc cref="JsonSerializer.Serialize{TValue}(Stream, TValue, JsonSerializerOptions?)"/>
         public byte[] SerializeAsByteBuffer<TData>(TData data)
         {
-            var ms = new MemoryStream();
+            MemoryStream ms = RecyclableMemoryStreamSupport.Rent();
             JsonSerializer.Serialize(ms, data, DefautJsonOptions);
             return ByteBuffer.From(ms);
         }
         /// <inheritdoc cref="JsonSerializer.Serialize(Stream, object?, Type, JsonSerializerOptions?)"/>
         public byte[] SerializeAsByteBuffer(Type type, object data)
         {
-            var ms = new MemoryStream();
+            MemoryStream ms = RecyclableMemoryStreamSupport.Rent();
             JsonSerializer.Serialize(ms, data, type, DefautJsonOptions);
             return ByteBuffer.From(ms);
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Adds a new support class RecyclableMemoryStreamSupport which act as a proxy on generation of MemoryStream. By default it is disable and MemoryStream generated are the standard one, if the class is enabled using the SetEnable method the buffer returned are of type RecyclableMemoryStream which helps to reduce memory pressure resusing MemoryStream across requests.

>[!Important]
> The default options are copied from documentation [Microsoft.IO.RecyclableMemoryStream](https://www.nuget.org/packages/Microsoft.IO.RecyclableMemoryStream#readme-body-tab) and the user shall select them after tests based on the managed data

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
