### PR TITLE
Separate singleton and context-scoped options in IKEFCoreSingletonOptions

### DIFF
--- a/src/documentation/articles/kefcoredbcontext.md
+++ b/src/documentation/articles/kefcoredbcontext.md
@@ -19,7 +19,8 @@ _description: Describe what is and how use KEFCoreDbContext class from Entity Fr
   - **DefaultConsumerInstances**: the consumer instances to be allocated when UseCompactedReplicator is **true**
   - **UsePersistentStorage**: set to **true** to use a persistent storage between multiple application startup
   - **UseEnumeratorWithPrefetch**: set to **true** to prefer enumerator instances able to do a prefetch on data speeding up execution, used if **UseKNetStreams** is **true** and **UseCompactedReplicator** is **false**
-  - **UseByteBufferDataTransfer**: set to **true** to prefer <see cref="Java.Nio.ByteBuffer"/> data exchange in serializer instances
+  - **UseKeyByteBufferDataTransfer**: set to **true** to prefer <see cref="Java.Nio.ByteBuffer"/> data exchange in serializer instances for keys
+  - **UseValueContainerByteBufferDataTransfer**: set to **true** to prefer <see cref="Java.Nio.ByteBuffer"/> data exchange in serializer instances for value container
   - **UseDeletePolicyForTopic**: set to **true** to enable [delete cleanup policy](https://kafka.apache.org/documentation/#topicconfigs_cleanup.policy)
   - ~~**UseCompactedReplicator**: Use `KNetCompactedReplicator` instead of Apache Kafka™ Streams to manage data to or from topics~~
   - **UseKNetStreams**: Setting this property to true the KNet version of Apache Kafka™ Streams is used instead of standard Apache Kafka™ Streams, the property is used if **UseCompactedReplicator** is **false**

--- a/src/net/KEFCore/Design/Internal/KEFCoreDesignTimeServices.cs
+++ b/src/net/KEFCore/Design/Internal/KEFCoreDesignTimeServices.cs
@@ -16,6 +16,7 @@
 *  Refer to LICENSE for more information.
 */
 
+using MASES.EntityFrameworkCore.KNet.Extensions;
 using Microsoft.EntityFrameworkCore.Design.Internal;
 
 [assembly: DesignTimeProviderServices("MASES.EntityFrameworkCore.KNet.Design.Internal.KEFCoreDesignTimeServices")]

--- a/src/net/KEFCore/Extensions/KEFCoreDatabaseFacadeExtensions.cs
+++ b/src/net/KEFCore/Extensions/KEFCoreDatabaseFacadeExtensions.cs
@@ -18,7 +18,7 @@
 
 using MASES.EntityFrameworkCore.KNet.Infrastructure.Internal;
 
-namespace MASES.EntityFrameworkCore.KNet;
+namespace MASES.EntityFrameworkCore.KNet.Extensions;
 
 /// <summary>
 ///     KEFCore specific extension methods for <see cref="DbContext.Database" />.

--- a/src/net/KEFCore/Extensions/KEFCoreDbContextOptionsExtensions.cs
+++ b/src/net/KEFCore/Extensions/KEFCoreDbContextOptionsExtensions.cs
@@ -133,6 +133,19 @@ public static class KEFCoreDbContextOptionsExtensions
     /// </summary>
     public static Type JVMKeyType(this IKEFCoreSingletonOptions options, IEntityType entityType)
     {
+        var selector = SerDesSelectorForKey(options, entityType);
+        if (options.UseKeyByteBufferDataTransfer)
+        {
+            if (selector == null || selector.ByteBufferSerDes == null)
+            {
+                throw new InvalidOperationException($"UseKeyByteBufferDataTransfer needs a serializer which supports it, current serializer is {options.KeySerDesSelectorType}");
+            }
+            return typeof(Java.Nio.ByteBuffer);
+        }
+        else if (selector == null || selector.ByteArraySerDes == null)
+        {
+            throw new InvalidOperationException($"Raw array data transfer needs a serializer which supports it, current serializer is {options.KeySerDesSelectorType}");
+        }
         return typeof(byte[]);
     }
     /// <summary>
@@ -141,7 +154,18 @@ public static class KEFCoreDbContextOptionsExtensions
     public static Type JVMValueContainerType(this IKEFCoreSingletonOptions options, IEntityType entityType)
     {
         var selector = SerDesSelectorForValue(options, entityType);
-        if (options.UseByteBufferDataTransfer && selector != null && selector.ByteBufferSerDes != null) return typeof(Java.Nio.ByteBuffer);
+        if (options.UseValueContainerByteBufferDataTransfer)
+        {
+            if (selector == null || selector.ByteBufferSerDes == null)
+            {
+                throw new InvalidOperationException($"UseValueContainerByteBufferDataTransfer needs a serializer which supports it, current serializer is {options.ValueSerDesSelectorType}");
+            }
+            return typeof(Java.Nio.ByteBuffer);
+        }
+        else if (selector == null || selector.ByteArraySerDes == null)
+        {
+            throw new InvalidOperationException($"Byte array data transfer needs a serializer which supports it, current serializer is {options.ValueSerDesSelectorType}");
+        }
         return typeof(byte[]);
     }
 

--- a/src/net/KEFCore/Extensions/KEFCoreDbContextOptionsExtensions.cs
+++ b/src/net/KEFCore/Extensions/KEFCoreDbContextOptionsExtensions.cs
@@ -22,7 +22,7 @@ using MASES.EntityFrameworkCore.KNet.Infrastructure.Internal;
 using MASES.KNet.Serialization;
 using System.Collections.Concurrent;
 
-namespace MASES.EntityFrameworkCore.KNet;
+namespace MASES.EntityFrameworkCore.KNet.Extensions;
 
 /// <summary>
 ///     KEFCore specific extension methods for <see cref="DbContextOptionsBuilder" />.
@@ -126,7 +126,7 @@ public static class KEFCoreDbContextOptionsExtensions
     /// </summary>
     public static Type ValueContainerType(this IKEFCoreSingletonOptions options, IEntityType entityType)
     {
-        return options.ValueContainerType?.MakeGenericType(KeyType(options, entityType))!;
+        return options.ValueContainerType?.MakeGenericType(options.KeyType(entityType))!;
     }
     /// <summary>
     /// Create the ValueContainer <see cref="Type"/>
@@ -154,7 +154,7 @@ public static class KEFCoreDbContextOptionsExtensions
     {
         return _keySerDesSelctors.GetOrAdd((options.KeySerDesSelectorType, entityType), (o) =>
         {
-            var selector = o.Item1?.MakeGenericType(KeyType(options, o.Item2))!;
+            var selector = o.Item1?.MakeGenericType(options.KeyType(o.Item2))!;
             return Activator.CreateInstance(selector) as ISerDesSelector;
         });
     }
@@ -168,7 +168,7 @@ public static class KEFCoreDbContextOptionsExtensions
     {
         return _valueContainerSerDesSelctors.GetOrAdd((options.ValueSerDesSelectorType, entityType), (o) =>
         {
-            var selector = o.Item1?.MakeGenericType(ValueContainerType(options, o.Item2))!;
+            var selector = o.Item1?.MakeGenericType(options.ValueContainerType(o.Item2))!;
             return Activator.CreateInstance(selector) as ISerDesSelector;
         });
     }

--- a/src/net/KEFCore/Extensions/KEFCoreEntityTypeBuilderExtensions.cs
+++ b/src/net/KEFCore/Extensions/KEFCoreEntityTypeBuilderExtensions.cs
@@ -18,7 +18,7 @@
 
 using MASES.EntityFrameworkCore.KNet.Metadata.Internal;
 
-namespace MASES.EntityFrameworkCore.KNet;
+namespace MASES.EntityFrameworkCore.KNet.Extensions;
 
 /// <summary>
 ///     Extension methods for <see cref="EntityTypeBuilder" /> for the Kafka provider.

--- a/src/net/KEFCore/Extensions/KEFCoreEntityTypeExtensions.cs
+++ b/src/net/KEFCore/Extensions/KEFCoreEntityTypeExtensions.cs
@@ -18,10 +18,9 @@
 
 using MASES.EntityFrameworkCore.KNet.Infrastructure.Internal;
 using MASES.EntityFrameworkCore.KNet.Metadata.Internal;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using System.ComponentModel.DataAnnotations.Schema;
 
-namespace MASES.EntityFrameworkCore.KNet;
+namespace MASES.EntityFrameworkCore.KNet.Extensions;
 
 /// <summary>
 ///     Extension methods for <see cref="IReadOnlyEntityType" /> for the Kafka provider.

--- a/src/net/KEFCore/Extensions/KEFCoreServiceCollectionExtensions.cs
+++ b/src/net/KEFCore/Extensions/KEFCoreServiceCollectionExtensions.cs
@@ -26,7 +26,7 @@ using MASES.EntityFrameworkCore.KNet.Storage.Internal;
 using MASES.EntityFrameworkCore.KNet.ValueGeneration.Internal;
 using System.ComponentModel;
 
-namespace Microsoft.Extensions.DependencyInjection;
+namespace MASES.EntityFrameworkCore.KNet.Extensions;
 
 /// <summary>
 ///     KEFCore specific extension methods for <see cref="IServiceCollection" />.
@@ -54,7 +54,7 @@ public static class KEFCoreServiceCollectionExtensions
     {
         var builder = new EntityFrameworkServicesBuilder(serviceCollection)
             .TryAdd<LoggingDefinitions, KEFCoreLoggingDefinitions>()
-            .TryAdd<EntityFrameworkCore.Internal.IEntityFinderSource, KEFCoreEntityFinderSource>()
+            .TryAdd<Microsoft.EntityFrameworkCore.Internal.IEntityFinderSource, KEFCoreEntityFinderSource>()
             .TryAdd<IDatabaseProvider, DatabaseProvider<KEFCoreOptionsExtension>>()
             .TryAdd<IValueGeneratorSelector, KEFCoreValueGeneratorSelector>()
             .TryAdd<IDatabase>(p => p.GetRequiredService<IKEFCoreDatabase>())

--- a/src/net/KEFCore/Infrastructure/Internal/IKEFCoreSingletonOptions.cs
+++ b/src/net/KEFCore/Infrastructure/Internal/IKEFCoreSingletonOptions.cs
@@ -41,8 +41,10 @@ public interface IKEFCoreSingletonOptions : ISingletonOptions
     Type ValueSerDesSelectorType { get; }
     /// <inheritdoc cref="KEFCoreDbContext.ValueContainerType"/>
     Type ValueContainerType { get; }
-    /// <inheritdoc cref="KEFCoreDbContext.UseByteBufferDataTransfer"/>
-    bool UseByteBufferDataTransfer { get; }
+    /// <inheritdoc cref="KEFCoreDbContext.UseKeyByteBufferDataTransfer"/>
+    bool UseKeyByteBufferDataTransfer { get; }
+    /// <inheritdoc cref="KEFCoreDbContext.UseValueContainerByteBufferDataTransfer"/>
+    bool UseValueContainerByteBufferDataTransfer { get; }
 
     // ── Cluster — BootstrapServers used to resolve ClusterId (in hash) ────
     /// <inheritdoc cref="KEFCoreDbContext.BootstrapServers"/>

--- a/src/net/KEFCore/Infrastructure/Internal/IKEFCoreSingletonOptions.cs
+++ b/src/net/KEFCore/Infrastructure/Internal/IKEFCoreSingletonOptions.cs
@@ -19,9 +19,6 @@
 #nullable enable
 
 using MASES.KNet.Common;
-using MASES.KNet.Consumer;
-using MASES.KNet.Producer;
-using MASES.KNet.Streams;
 
 namespace MASES.EntityFrameworkCore.KNet.Infrastructure.Internal;
 /// <summary>
@@ -30,53 +27,43 @@ namespace MASES.EntityFrameworkCore.KNet.Infrastructure.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
+/// <remarks>
+/// Options that affect the Service Provider (singleton-scoped).
+/// EF Core uses these to decide whether to reuse the cached SP.
+/// All contexts pointing to the same physical cluster share these.
+/// </remarks>
 public interface IKEFCoreSingletonOptions : ISingletonOptions
 {
+    // ── Serialization — in hash ───────────────────────────────────────────
     /// <inheritdoc cref="KEFCoreDbContext.KeySerDesSelectorType"/>
-    Type? KeySerDesSelectorType { get; }
+    Type KeySerDesSelectorType { get; }
     /// <inheritdoc cref="KEFCoreDbContext.ValueSerDesSelectorType"/>
-    Type? ValueSerDesSelectorType { get; }
+    Type ValueSerDesSelectorType { get; }
     /// <inheritdoc cref="KEFCoreDbContext.ValueContainerType"/>
-    Type? ValueContainerType { get; }
-    /// <inheritdoc cref="KEFCoreDbContext.TopicPrefix"/>
-    string? TopicPrefix { get; }
-    /// <inheritdoc cref="KEFCoreDbContext.ApplicationId"/>
-    string? ApplicationId { get; }
+    Type ValueContainerType { get; }
+    /// <inheritdoc cref="KEFCoreDbContext.UseByteBufferDataTransfer"/>
+    bool UseByteBufferDataTransfer { get; }
+
+    // ── Cluster — BootstrapServers used to resolve ClusterId (in hash) ────
     /// <inheritdoc cref="KEFCoreDbContext.BootstrapServers"/>
     string? BootstrapServers { get; }
-    /// <inheritdoc cref="KEFCoreDbContext.UseDeletePolicyForTopic"/>
-    bool UseDeletePolicyForTopic { get; }
+
+    // ── Backend architecture — in hash ────────────────────────────────────
+    /// <inheritdoc cref="KEFCoreDbContext.UseKNetStreams"/>
+    bool UseKNetStreams { get; }
+    /// <inheritdoc cref="KEFCoreDbContext.UsePersistentStorage"/>
+    bool UsePersistentStorage { get; }
     /// <inheritdoc cref="KEFCoreDbContext.UseCompactedReplicator"/>
     [Obsolete("Option will be removed soon")]
     bool UseCompactedReplicator { get; }
-    /// <inheritdoc cref="KEFCoreDbContext.UseKNetStreams"/>
-    bool UseKNetStreams { get; }
-    /// <inheritdoc cref="KEFCoreDbContext.UseGlobalTable"/>
-    bool UseGlobalTable { get; }
-    /// <inheritdoc cref="KEFCoreDbContext.UsePersistentStorage"/>
-    bool UsePersistentStorage { get; }
-    /// <inheritdoc cref="KEFCoreDbContext.UseEnumeratorWithPrefetch"/>
-    bool UseEnumeratorWithPrefetch { get; }
-    /// <inheritdoc cref="KEFCoreDbContext.UseByteBufferDataTransfer"/>
-    bool UseByteBufferDataTransfer { get; }
+
+    // ── Topic structure — NOT in hash (first-wins at topic creation) ──────
+    /// <inheritdoc cref="KEFCoreDbContext.UseDeletePolicyForTopic"/>
+    bool UseDeletePolicyForTopic { get; }
     /// <inheritdoc cref="KEFCoreDbContext.DefaultNumPartitions"/>
     int DefaultNumPartitions { get; }
-    /// <inheritdoc cref="KEFCoreDbContext.DefaultConsumerInstances"/>
-    int? DefaultConsumerInstances { get; }
     /// <inheritdoc cref="KEFCoreDbContext.DefaultReplicationFactor"/>
     int DefaultReplicationFactor { get; }
-    /// <inheritdoc cref="KEFCoreDbContext.ConsumerConfig"/>
-    ConsumerConfigBuilder? ConsumerConfig { get; }
-    /// <inheritdoc cref="KEFCoreDbContext.ProducerConfig"/>
-    ProducerConfigBuilder? ProducerConfig { get; }
-    /// <inheritdoc cref="KEFCoreDbContext.StreamsConfig"/>
-    StreamsConfigBuilder? StreamsConfig { get; }
     /// <inheritdoc cref="KEFCoreDbContext.TopicConfig"/>
     TopicConfigBuilder? TopicConfig { get; }
-    /// <inheritdoc cref="KEFCoreDbContext.ManageEvents"/>
-    bool ManageEvents { get; }
-    /// <inheritdoc cref="KEFCoreDbContext.ReadOnlyMode"/>
-    bool ReadOnlyMode { get; }
-    /// <inheritdoc cref="KEFCoreDbContext.DefaultSynchronizationTimeout"/>
-    long DefaultSynchronizationTimeout { get; }
 }

--- a/src/net/KEFCore/Infrastructure/Internal/KEFCoreModelValidator.cs
+++ b/src/net/KEFCore/Infrastructure/Internal/KEFCoreModelValidator.cs
@@ -16,6 +16,8 @@
 *  Refer to LICENSE for more information.
 */
 
+using MASES.EntityFrameworkCore.KNet.Extensions;
+
 namespace MASES.EntityFrameworkCore.KNet.Infrastructure.Internal;
 /// <summary>
 ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/net/KEFCore/Infrastructure/Internal/KEFCoreOptionsExtension.cs
+++ b/src/net/KEFCore/Infrastructure/Internal/KEFCoreOptionsExtension.cs
@@ -20,6 +20,7 @@
 
 using Java.Lang;
 using Java.Util;
+using MASES.EntityFrameworkCore.KNet.Extensions;
 using MASES.EntityFrameworkCore.KNet.Serialization.Json;
 using MASES.EntityFrameworkCore.KNet.Storage.Internal;
 using MASES.KNet.Common;
@@ -40,48 +41,54 @@ public class KEFCoreOptionsExtension : IDbContextOptionsExtension, IKEFCoreSingl
 {
     private readonly object _clusterIdLock = new();
     private string _clusterId = null!;
-
     private DbContextOptionsExtensionInfo? _info;
-
     /// <summary>
-    /// Initializer
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public KEFCoreOptionsExtension()
-    {
-    }
+    public KEFCoreOptionsExtension() { }
     /// <summary>
-    /// Initializer
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     protected KEFCoreOptionsExtension(KEFCoreOptionsExtension copyFrom)
     {
+        // ── Singleton options ─────────────────────────────────────────────
         KeySerDesSelectorType = copyFrom.KeySerDesSelectorType;
         ValueSerDesSelectorType = copyFrom.ValueSerDesSelectorType;
         ValueContainerType = copyFrom.ValueContainerType;
+        UseByteBufferDataTransfer = copyFrom.UseByteBufferDataTransfer;
+        BootstrapServers = copyFrom.BootstrapServers;
+        UseKNetStreams = copyFrom.UseKNetStreams;
+        UsePersistentStorage = copyFrom.UsePersistentStorage;
+        UseCompactedReplicator = copyFrom.UseCompactedReplicator;
+        UseDeletePolicyForTopic = copyFrom.UseDeletePolicyForTopic;
+        DefaultNumPartitions = copyFrom.DefaultNumPartitions;
+        DefaultReplicationFactor = copyFrom.DefaultReplicationFactor;
+        TopicConfig = TopicConfigBuilder.CreateFrom(copyFrom.TopicConfig);
+        // obsolete
+        DefaultConsumerInstances = copyFrom.DefaultConsumerInstances;
+        ConsumerConfig = ConsumerConfigBuilder.CreateFrom(copyFrom.ConsumerConfig);
+
+        // ── Context-only options ──────────────────────────────────────────
         TopicPrefix = copyFrom.TopicPrefix;
         ApplicationId = copyFrom.ApplicationId;
-        BootstrapServers = copyFrom.BootstrapServers;
-        UseDeletePolicyForTopic = copyFrom.UseDeletePolicyForTopic;
-        UseCompactedReplicator = copyFrom.UseCompactedReplicator;
-        UseKNetStreams = copyFrom.UseKNetStreams;
-        UseGlobalTable = copyFrom.UseGlobalTable;
-        UsePersistentStorage = copyFrom.UsePersistentStorage;
-        UseEnumeratorWithPrefetch = copyFrom.UseEnumeratorWithPrefetch;
-        UseByteBufferDataTransfer = copyFrom.UseByteBufferDataTransfer;
-        DefaultNumPartitions = copyFrom.DefaultNumPartitions;
-        DefaultConsumerInstances = copyFrom.DefaultConsumerInstances;
-        DefaultReplicationFactor = copyFrom.DefaultReplicationFactor;
-        ConsumerConfig = ConsumerConfigBuilder.CreateFrom(copyFrom.ConsumerConfig);
         ProducerConfig = ProducerConfigBuilder.CreateFrom(copyFrom.ProducerConfig);
         StreamsConfig = StreamsConfigBuilder.CreateFrom(copyFrom.StreamsConfig);
-        TopicConfig = TopicConfigBuilder.CreateFrom(copyFrom.TopicConfig);
         ManageEvents = copyFrom.ManageEvents;
         ReadOnlyMode = copyFrom.ReadOnlyMode;
         DefaultSynchronizationTimeout = copyFrom.DefaultSynchronizationTimeout;
+        UseEnumeratorWithPrefetch = copyFrom.UseEnumeratorWithPrefetch;
         UseStorePrefixScan = copyFrom.UseStorePrefixScan;
         UseStoreSingleKeyLookup = copyFrom.UseStoreSingleKeyLookup;
         UseStoreKeyRange = copyFrom.UseStoreKeyRange;
         UseStoreReverse = copyFrom.UseStoreReverse;
         UseStoreReverseKeyRange = copyFrom.UseStoreReverseKeyRange;
+        UseGlobalTable = copyFrom.UseGlobalTable;
     }
     /// <inheritdoc/>
     public virtual DbContextOptionsExtensionInfo Info => _info ??= new ExtensionInfo(this);
@@ -102,52 +109,60 @@ public class KEFCoreOptionsExtension : IDbContextOptionsExtension, IKEFCoreSingl
             }
         }
     }
+
+    // ── Singleton options ─────────────────────────────────────────────────
+
     /// <inheritdoc cref="KEFCoreDbContext.KeySerDesSelectorType"/>
     public virtual Type KeySerDesSelectorType { get; set; } = DefaultKEFCoreSerDes.DefaultKeySerialization;
     /// <inheritdoc cref="KEFCoreDbContext.ValueSerDesSelectorType"/>
     public virtual Type ValueSerDesSelectorType { get; set; } = DefaultKEFCoreSerDes.DefaultValueContainerSerialization;
     /// <inheritdoc cref="KEFCoreDbContext.ValueContainerType"/>
     public virtual Type ValueContainerType { get; set; } = DefaultKEFCoreSerDes.DefaultValueContainer;
+    /// <inheritdoc cref="KEFCoreDbContext.UseByteBufferDataTransfer"/>
+    public virtual bool UseByteBufferDataTransfer { get; set; } = false;
+    /// <inheritdoc cref="KEFCoreDbContext.BootstrapServers"/>
+    public virtual string? BootstrapServers { get; set; }
+    /// <inheritdoc cref="KEFCoreDbContext.UseKNetStreams"/>
+    public virtual bool UseKNetStreams { get; set; } = true;
+    /// <inheritdoc cref="KEFCoreDbContext.UsePersistentStorage"/>
+    public virtual bool UsePersistentStorage { get; set; } = false;
+    /// <inheritdoc cref="KEFCoreDbContext.UseCompactedReplicator"/>
+    [Obsolete("Option will be removed soon")]
+    public virtual bool UseCompactedReplicator { get; set; } = false;
+    /// <inheritdoc cref="KEFCoreDbContext.UseDeletePolicyForTopic"/>
+    public virtual bool UseDeletePolicyForTopic { get; set; } = false;
+    /// <inheritdoc cref="KEFCoreDbContext.DefaultNumPartitions"/>
+    public virtual int DefaultNumPartitions { get; set; } = 1;
+    /// <inheritdoc cref="KEFCoreDbContext.DefaultReplicationFactor"/>
+    public virtual short DefaultReplicationFactor { get; set; } = 1;
+    /// <inheritdoc cref="KEFCoreDbContext.TopicConfig"/>
+    public virtual TopicConfigBuilder? TopicConfig { get; set; }
+    // explicit per il mismatch short/int nell'interfaccia
+    int IKEFCoreSingletonOptions.DefaultReplicationFactor => DefaultReplicationFactor;
+
+    // ── Context-only options ──────────────────────────────────────────────
+    /// <inheritdoc cref="KEFCoreDbContext.DefaultConsumerInstances"/>
+    [Obsolete("Option will be removed soon")]
+    public virtual int? DefaultConsumerInstances { get; set; } = null;
+    /// <inheritdoc cref="KEFCoreDbContext.ConsumerConfig"/>
+    [Obsolete("Option will be removed soon")]
+    public virtual ConsumerConfigBuilder? ConsumerConfig { get; set; }
     /// <inheritdoc cref="KEFCoreDbContext.TopicPrefix"/>
     public virtual string? TopicPrefix { get; set; }
     /// <inheritdoc cref="KEFCoreDbContext.ApplicationId"/>
     public virtual string? ApplicationId { get; set; }
-    /// <inheritdoc cref="KEFCoreDbContext.BootstrapServers"/>
-    public virtual string? BootstrapServers { get; set; }
-    /// <inheritdoc cref="KEFCoreDbContext.UseDeletePolicyForTopic"/>
-    public virtual bool UseDeletePolicyForTopic { get; set; } = false;
-    /// <inheritdoc cref="KEFCoreDbContext.UseCompactedReplicator"/>
-    public virtual bool UseCompactedReplicator { get; set; } = false;
-    /// <inheritdoc cref="KEFCoreDbContext.UseKNetStreams"/>
-    public virtual bool UseKNetStreams { get; set; } = true;
-    /// <inheritdoc cref="KEFCoreDbContext.UseGlobalTable"/>
-    public virtual bool UseGlobalTable { get; set; } = false;
-    /// <inheritdoc cref="KEFCoreDbContext.UsePersistentStorage"/>
-    public virtual bool UsePersistentStorage { get; set; } = false;
-    /// <inheritdoc cref="KEFCoreDbContext.UseByteBufferDataTransfer"/>
-    public virtual bool UseByteBufferDataTransfer { get; set; } = false;
-    /// <inheritdoc cref="KEFCoreDbContext.UseEnumeratorWithPrefetch"/>
-    public virtual bool UseEnumeratorWithPrefetch { get; set; } = true;
-    /// <inheritdoc cref="KEFCoreDbContext.DefaultNumPartitions"/>
-    public virtual int DefaultNumPartitions { get; set; } = 1;
-    /// <inheritdoc cref="KEFCoreDbContext.DefaultConsumerInstances"/>
-    public virtual int? DefaultConsumerInstances { get; set; } = null;
-    /// <inheritdoc cref="KEFCoreDbContext.DefaultReplicationFactor"/>
-    public virtual short DefaultReplicationFactor { get; set; } = 1;
-    /// <inheritdoc cref="KEFCoreDbContext.ConsumerConfig"/>
-    public virtual ConsumerConfigBuilder? ConsumerConfig { get; set; }
     /// <inheritdoc cref="KEFCoreDbContext.ProducerConfig"/>
     public virtual ProducerConfigBuilder? ProducerConfig { get; set; }
     /// <inheritdoc cref="KEFCoreDbContext.StreamsConfig"/>
     public virtual StreamsConfigBuilder? StreamsConfig { get; set; }
-    /// <inheritdoc cref="KEFCoreDbContext.TopicConfig"/>
-    public virtual TopicConfigBuilder? TopicConfig { get; set; }
     /// <inheritdoc cref="KEFCoreDbContext.ManageEvents"/>
     public virtual bool ManageEvents { get; set; } = false;
     /// <inheritdoc cref="KEFCoreDbContext.ReadOnlyMode"/>
     public virtual bool ReadOnlyMode { get; set; } = false;
     /// <inheritdoc cref="KEFCoreDbContext.DefaultSynchronizationTimeout"/>
     public virtual long DefaultSynchronizationTimeout { get; set; } = Timeout.Infinite;
+    /// <inheritdoc cref="KEFCoreDbContext.UseEnumeratorWithPrefetch"/>
+    public virtual bool UseEnumeratorWithPrefetch { get; set; } = true;
     /// <inheritdoc cref="KEFCoreDbContext.UseStorePrefixScan"/>
     public virtual bool UseStorePrefixScan { get; set; } = false;
     /// <inheritdoc cref="KEFCoreDbContext.UseStoreSingleKeyLookup"/>
@@ -158,76 +173,64 @@ public class KEFCoreOptionsExtension : IDbContextOptionsExtension, IKEFCoreSingl
     public virtual bool UseStoreReverse { get; private set; } = true;
     /// <inheritdoc cref="KEFCoreDbContext.UseStoreReverseKeyRange"/>
     public virtual bool UseStoreReverseKeyRange { get; private set; } = true;
+    /// <inheritdoc cref="KEFCoreDbContext.UseGlobalTable"/>
+    [Obsolete("ApplicationId must be unique per process — UseGlobalTable is no longer needed.")]
+    public virtual bool UseGlobalTable { get; set; } = false;
 
-    int IKEFCoreSingletonOptions.DefaultReplicationFactor => DefaultReplicationFactor;
-
+    // ── With* methods — singleton ─────────────────────────────────────────
     /// <inheritdoc cref="KEFCoreDbContext.KeySerDesSelectorType"/>
     public virtual KEFCoreOptionsExtension WithKeySerDesSelectorType(Type serializationType)
     {
-        if (!serializationType.IsGenericTypeDefinition) throw new InvalidOperationException($"{serializationType.Name} shall be a generic type and shall be defined using \"<>\"");
-
+        if (!serializationType.IsGenericTypeDefinition)
+            throw new InvalidOperationException($"{serializationType.Name} shall be a generic type and shall be defined using \"<>\"");
         var clone = Clone();
-
         clone.KeySerDesSelectorType = serializationType;
-
         return clone;
     }
     /// <inheritdoc cref="KEFCoreDbContext.ValueSerDesSelectorType"/>
     public virtual KEFCoreOptionsExtension WithValueSerDesSelectorType(Type serializationType)
     {
-        if (!serializationType.IsGenericTypeDefinition) throw new InvalidOperationException($"{serializationType.Name} shall be a generic type and shall be defined using \"<>\"");
-
+        if (!serializationType.IsGenericTypeDefinition)
+            throw new InvalidOperationException($"{serializationType.Name} shall be a generic type and shall be defined using \"<>\"");
         var clone = Clone();
-
         clone.ValueSerDesSelectorType = serializationType;
-
         return clone;
     }
     /// <inheritdoc cref="KEFCoreDbContext.ValueContainerType"/>
     public virtual KEFCoreOptionsExtension WithValueContainerType(Type serializationType)
     {
-        if (!serializationType.IsGenericTypeDefinition) throw new InvalidOperationException($"{serializationType.Name} shall be a generic type and shall be defined using \"<>\"");
-
+        if (!serializationType.IsGenericTypeDefinition)
+            throw new InvalidOperationException($"{serializationType.Name} shall be a generic type and shall be defined using \"<>\"");
         var clone = Clone();
-
         clone.ValueContainerType = serializationType;
-
         return clone;
     }
-    /// <inheritdoc cref="KEFCoreDbContext.TopicPrefix"/>
-    public virtual KEFCoreOptionsExtension WithTopicPrefix(string? topicPrefix)
+    /// <inheritdoc cref="KEFCoreDbContext.UseByteBufferDataTransfer"/>
+    public virtual KEFCoreOptionsExtension WithByteBufferDataTransfer(bool useByteBufferDataTransfer = true)
     {
         var clone = Clone();
-
-        clone.TopicPrefix = topicPrefix;
-
-        return clone;
-    }
-    /// <inheritdoc cref="KEFCoreDbContext.ApplicationId"/>
-    public virtual KEFCoreOptionsExtension WithApplicationId(string? applicationId)
-    {
-        var clone = Clone();
-
-        clone.ApplicationId = applicationId;
-
+        clone.UseByteBufferDataTransfer = useByteBufferDataTransfer;
         return clone;
     }
     /// <inheritdoc cref="KEFCoreDbContext.BootstrapServers"/>
     public virtual KEFCoreOptionsExtension WithBootstrapServers(string bootstrapServers)
     {
         var clone = Clone();
-
         clone.BootstrapServers = bootstrapServers;
-
         return clone;
     }
-    /// <inheritdoc cref="KEFCoreDbContext.UseDeletePolicyForTopic"/>
-    public virtual KEFCoreOptionsExtension WithUseDeletePolicyForTopic(bool useDeletePolicyForTopic = true)
+    /// <inheritdoc cref="KEFCoreDbContext.UseKNetStreams"/>
+    public virtual KEFCoreOptionsExtension WithKNetStreams(bool useKNetStreams = true)
     {
         var clone = Clone();
-
-        clone.UseDeletePolicyForTopic = useDeletePolicyForTopic;
-
+        clone.UseKNetStreams = useKNetStreams;
+        return clone;
+    }
+    /// <inheritdoc cref="KEFCoreDbContext.UsePersistentStorage"/>
+    public virtual KEFCoreOptionsExtension WithPersistentStorage(bool usePersistentStorage = true)
+    {
+        var clone = Clone();
+        clone.UsePersistentStorage = usePersistentStorage;
         return clone;
     }
     /// <inheritdoc cref="KEFCoreDbContext.UseCompactedReplicator"/>
@@ -235,150 +238,112 @@ public class KEFCoreOptionsExtension : IDbContextOptionsExtension, IKEFCoreSingl
     public virtual KEFCoreOptionsExtension WithCompactedReplicator(bool useCompactedReplicator = true)
     {
         var clone = Clone();
-
         clone.UseCompactedReplicator = useCompactedReplicator;
-
         return clone;
     }
-    /// <inheritdoc cref="KEFCoreDbContext.UseKNetStreams"/>
-    public virtual KEFCoreOptionsExtension WithUseKNetStreams(bool useKNetStreams = true)
+    /// <inheritdoc cref="KEFCoreDbContext.UseDeletePolicyForTopic"/>
+    public virtual KEFCoreOptionsExtension WithDeletePolicyForTopic(bool useDeletePolicyForTopic = true)
     {
         var clone = Clone();
-
-        clone.UseKNetStreams = useKNetStreams;
-
-        return clone;
-    }
-    /// <inheritdoc cref="KEFCoreDbContext.UseGlobalTable"/>
-    public virtual KEFCoreOptionsExtension WithUseGlobalTable(bool useGlobalTable = true)
-    {
-        var clone = Clone();
-
-        clone.UseGlobalTable = useGlobalTable;
-
-        return clone;
-    }
-    /// <inheritdoc cref="KEFCoreDbContext.UsePersistentStorage"/>
-    public virtual KEFCoreOptionsExtension WithUsePersistentStorage(bool usePersistentStorage = true)
-    {
-        var clone = Clone();
-
-        clone.UsePersistentStorage = usePersistentStorage;
-
-        return clone;
-    }
-    /// <inheritdoc cref="KEFCoreDbContext.UseEnumeratorWithPrefetch"/>
-    public virtual KEFCoreOptionsExtension WithUseEnumeratorWithPrefetch(bool useEnumeratorWithPrefetch = true)
-    {
-        var clone = Clone();
-
-        clone.UseEnumeratorWithPrefetch = useEnumeratorWithPrefetch;
-
-        return clone;
-    }
-    /// <inheritdoc cref="KEFCoreDbContext.UseByteBufferDataTransfer"/>
-    public virtual KEFCoreOptionsExtension WithUseByteBufferDataTransfer(bool useByteBufferDataTransfer = true)
-    {
-        var clone = Clone();
-
-        clone.UseByteBufferDataTransfer = useByteBufferDataTransfer;
-
+        clone.UseDeletePolicyForTopic = useDeletePolicyForTopic;
         return clone;
     }
     /// <inheritdoc cref="KEFCoreDbContext.DefaultNumPartitions"/>
     public virtual KEFCoreOptionsExtension WithDefaultNumPartitions(int defaultNumPartitions = 1)
     {
         var clone = Clone();
-
         clone.DefaultNumPartitions = defaultNumPartitions;
-
-        return clone;
-    }
-    /// <inheritdoc cref="KEFCoreDbContext.DefaultConsumerInstances"/>
-    public virtual KEFCoreOptionsExtension WithDefaultConsumerInstances(int? defaultConsumerInstances = null)
-    {
-        var clone = Clone();
-
-        clone.DefaultConsumerInstances = defaultConsumerInstances;
-
         return clone;
     }
     /// <inheritdoc cref="KEFCoreDbContext.DefaultReplicationFactor"/>
     public virtual KEFCoreOptionsExtension WithDefaultReplicationFactor(short defaultReplicationFactor = 3)
     {
         var clone = Clone();
-
         clone.DefaultReplicationFactor = defaultReplicationFactor;
-
-        return clone;
-    }
-    /// <inheritdoc cref="KEFCoreDbContext.ConsumerConfig"/>
-    public virtual KEFCoreOptionsExtension WithConsumerConfig(ConsumerConfigBuilder consumerConfigBuilder)
-    {
-        var clone = Clone();
-
-        clone.ConsumerConfig = ConsumerConfigBuilder.CreateFrom(consumerConfigBuilder);
-
-        return clone;
-    }
-    /// <inheritdoc cref="KEFCoreDbContext.ProducerConfig"/>
-    public virtual KEFCoreOptionsExtension WithProducerConfig(ProducerConfigBuilder producerConfigBuilder)
-    {
-        var clone = Clone();
-
-        clone.ProducerConfig = ProducerConfigBuilder.CreateFrom(producerConfigBuilder);
-
-        return clone;
-    }
-    /// <inheritdoc cref="KEFCoreDbContext.StreamsConfig"/>
-    public virtual KEFCoreOptionsExtension WithStreamsConfig(StreamsConfigBuilder streamsConfigBuilder)
-    {
-        var clone = Clone();
-
-        clone.StreamsConfig = StreamsConfigBuilder.CreateFrom(streamsConfigBuilder);
-
         return clone;
     }
     /// <inheritdoc cref="KEFCoreDbContext.TopicConfig"/>
     public virtual KEFCoreOptionsExtension WithTopicConfig(TopicConfigBuilder topicConfigBuilder)
     {
         var clone = Clone();
-
         clone.TopicConfig = TopicConfigBuilder.CreateFrom(topicConfigBuilder);
-
         return clone;
     }
 
+    // ── With* methods — context ───────────────────────────────────────────
+    /// <inheritdoc cref="KEFCoreDbContext.DefaultConsumerInstances"/>
+    [Obsolete("Option will be removed soon")]
+    public virtual KEFCoreOptionsExtension WithDefaultConsumerInstances(int? defaultConsumerInstances = null)
+    {
+        var clone = Clone();
+        clone.DefaultConsumerInstances = defaultConsumerInstances;
+        return clone;
+    }
+    /// <inheritdoc cref="KEFCoreDbContext.ConsumerConfig"/>
+    [Obsolete("Option will be removed soon")]
+    public virtual KEFCoreOptionsExtension WithConsumerConfig(ConsumerConfigBuilder consumerConfigBuilder)
+    {
+        var clone = Clone();
+        clone.ConsumerConfig = ConsumerConfigBuilder.CreateFrom(consumerConfigBuilder);
+        return clone;
+    }
+
+    /// <inheritdoc cref="KEFCoreDbContext.TopicPrefix"/>
+    public virtual KEFCoreOptionsExtension WithTopicPrefix(string? topicPrefix)
+    {
+        var clone = Clone();
+        clone.TopicPrefix = topicPrefix;
+        return clone;
+    }
+    /// <inheritdoc cref="KEFCoreDbContext.ApplicationId"/>
+    public virtual KEFCoreOptionsExtension WithApplicationId(string? applicationId)
+    {
+        var clone = Clone();
+        clone.ApplicationId = applicationId;
+        return clone;
+    }
+    /// <inheritdoc cref="KEFCoreDbContext.ProducerConfig"/>
+    public virtual KEFCoreOptionsExtension WithProducerConfig(ProducerConfigBuilder producerConfigBuilder)
+    {
+        var clone = Clone();
+        clone.ProducerConfig = ProducerConfigBuilder.CreateFrom(producerConfigBuilder);
+        return clone;
+    }
+    /// <inheritdoc cref="KEFCoreDbContext.StreamsConfig"/>
+    public virtual KEFCoreOptionsExtension WithStreamsConfig(StreamsConfigBuilder streamsConfigBuilder)
+    {
+        var clone = Clone();
+        clone.StreamsConfig = StreamsConfigBuilder.CreateFrom(streamsConfigBuilder);
+        return clone;
+    }
     /// <inheritdoc cref="KEFCoreDbContext.ManageEvents"/>
     public virtual KEFCoreOptionsExtension WithManageEvents(bool manageEvents)
     {
         var clone = Clone();
-
         clone.ManageEvents = manageEvents;
-
         return clone;
     }
-
     /// <inheritdoc cref="KEFCoreDbContext.ReadOnlyMode"/>
     public virtual KEFCoreOptionsExtension WithReadOnlyMode(bool readOnlyMode)
     {
         var clone = Clone();
-
         clone.ReadOnlyMode = readOnlyMode;
-
         return clone;
     }
-
     /// <inheritdoc cref="KEFCoreDbContext.DefaultSynchronizationTimeout"/>
     public virtual KEFCoreOptionsExtension WithDefaultSynchronizationTimeout(long defaultSynchronizationTimeout)
     {
         var clone = Clone();
-
         clone.DefaultSynchronizationTimeout = defaultSynchronizationTimeout;
-
         return clone;
     }
-
+    /// <inheritdoc cref="KEFCoreDbContext.UseEnumeratorWithPrefetch"/>
+    public virtual KEFCoreOptionsExtension WithEnumeratorWithPrefetch(bool useEnumeratorWithPrefetch = true)
+    {
+        var clone = Clone();
+        clone.UseEnumeratorWithPrefetch = useEnumeratorWithPrefetch;
+        return clone;
+    }
     /// <inheritdoc cref="KEFCoreDbContext.UseStorePrefixScan"/>
     public virtual KEFCoreOptionsExtension WithStorePrefixScan(bool enabled = true)
     {
@@ -386,7 +351,6 @@ public class KEFCoreOptionsExtension : IDbContextOptionsExtension, IKEFCoreSingl
         clone.UseStorePrefixScan = enabled;
         return clone;
     }
-
     /// <inheritdoc cref="KEFCoreDbContext.UseStoreSingleKeyLookup"/>
     public virtual KEFCoreOptionsExtension WithStoreSingleKeyLookup(bool enabled = true)
     {
@@ -394,7 +358,6 @@ public class KEFCoreOptionsExtension : IDbContextOptionsExtension, IKEFCoreSingl
         clone.UseStoreSingleKeyLookup = enabled;
         return clone;
     }
-
     /// <inheritdoc cref="KEFCoreDbContext.UseStoreKeyRange"/>
     public virtual KEFCoreOptionsExtension WithStoreKeyRange(bool enabled = true)
     {
@@ -402,7 +365,6 @@ public class KEFCoreOptionsExtension : IDbContextOptionsExtension, IKEFCoreSingl
         clone.UseStoreKeyRange = enabled;
         return clone;
     }
-
     /// <inheritdoc cref="KEFCoreDbContext.UseStoreReverse"/>
     public virtual KEFCoreOptionsExtension WithStoreReverse(bool enabled = true)
     {
@@ -410,7 +372,6 @@ public class KEFCoreOptionsExtension : IDbContextOptionsExtension, IKEFCoreSingl
         clone.UseStoreReverse = enabled;
         return clone;
     }
-
     /// <inheritdoc cref="KEFCoreDbContext.UseStoreReverseKeyRange"/>
     public virtual KEFCoreOptionsExtension WithStoreReverseKeyRange(bool enabled = true)
     {
@@ -418,7 +379,14 @@ public class KEFCoreOptionsExtension : IDbContextOptionsExtension, IKEFCoreSingl
         clone.UseStoreReverseKeyRange = enabled;
         return clone;
     }
-
+    /// <inheritdoc cref="KEFCoreDbContext.UseGlobalTable"/>
+    [Obsolete("ApplicationId must be unique per process — UseGlobalTable is no longer needed.")]
+    public virtual KEFCoreOptionsExtension WithGlobalTable(bool useGlobalTable = true)
+    {
+        var clone = Clone();
+        clone.UseGlobalTable = useGlobalTable;
+        return clone;
+    }
 
     /// <summary>
     /// Build <see cref="StreamsConfigBuilder"/> from options
@@ -556,40 +524,54 @@ public class KEFCoreOptionsExtension : IDbContextOptionsExtension, IKEFCoreSingl
 
         return props;
     }
+
+    #region IDbContextOptionsExtension
+
     /// <inheritdoc/>
-    public virtual void ApplyServices(IServiceCollection services) => services.AddEntityFrameworkKNetDatabase();
+    public virtual void ApplyServices(IServiceCollection services)
+        => services.AddEntityFrameworkKNetDatabase();
     /// <inheritdoc/>
     public virtual void Validate(IDbContextOptions options)
     {
-        var kefcoreOptions = options.FindExtension<KEFCoreOptionsExtension>() ?? throw new InvalidOperationException($"Cannot find an instance of {nameof(KEFCoreOptionsExtension)}");
+        var kefcoreOptions = options.FindExtension<KEFCoreOptionsExtension>()
+            ?? throw new InvalidOperationException($"Cannot find an instance of {nameof(KEFCoreOptionsExtension)}");
         if (!UseCompactedReplicator && string.IsNullOrEmpty(ApplicationId))
-        {
             throw new ArgumentException("Cannot be null or empty when Streams based backend is in use.", nameof(ApplicationId));
-        }
-        if (string.IsNullOrEmpty(kefcoreOptions.BootstrapServers)) throw new ArgumentException("It is manadatory", "BootstrapServers");
+        if (string.IsNullOrEmpty(kefcoreOptions.BootstrapServers))
+            throw new ArgumentException("It is mandatory", "BootstrapServers");
     }
+
     /// <inheritdoc/>
     public void Initialize(IDbContextOptions options)
     {
-        var kefcoreOptions = options.FindExtension<KEFCoreOptionsExtension>() ?? throw new InvalidOperationException($"Cannot find an instance of {nameof(KEFCoreOptionsExtension)}");
+        var other = options.FindExtension<KEFCoreOptionsExtension>()
+            ?? throw new InvalidOperationException($"Cannot find an instance of {nameof(KEFCoreOptionsExtension)}");
 
-        if (kefcoreOptions?.ClusterId != ClusterId)
+        if (other.ClusterId != ClusterId
+            || other.KeySerDesSelectorType != KeySerDesSelectorType
+            || other.ValueSerDesSelectorType != ValueSerDesSelectorType
+            || other.ValueContainerType != ValueContainerType
+            || other.UseByteBufferDataTransfer != UseByteBufferDataTransfer
+            || other.UseKNetStreams != UseKNetStreams
+            || other.UsePersistentStorage != UsePersistentStorage
+            || other.UseCompactedReplicator != UseCompactedReplicator)
         {
             throw new InvalidOperationException(
-                $"Cannot reuse internal service provider: ClusterId mismatch " +
-                $"(expected '{ClusterId}', got '{kefcoreOptions?.ClusterId}')");
+                "Cannot reuse internal service provider: singleton options mismatch.");
         }
     }
 
-    private sealed class ExtensionInfo(IDbContextOptionsExtension extension) : DbContextOptionsExtensionInfo(extension)
+    #endregion
+
+    #region ExtensionInfo
+
+    private sealed class ExtensionInfo(IDbContextOptionsExtension extension)
+        : DbContextOptionsExtensionInfo(extension)
     {
         private string? _logFragment;
+        private new KEFCoreOptionsExtension Extension => (KEFCoreOptionsExtension)base.Extension;
 
-        private new KEFCoreOptionsExtension Extension
-            => (KEFCoreOptionsExtension)base.Extension;
-
-        public override bool IsDatabaseProvider
-            => true;
+        public override bool IsDatabaseProvider => true;
 
         public override string LogFragment
         {
@@ -598,51 +580,74 @@ public class KEFCoreOptionsExtension : IDbContextOptionsExtension, IKEFCoreSingl
                 if (_logFragment == null)
                 {
                     var builder = new System.Text.StringBuilder();
-
+                    // singleton
                     builder.Append("KeySerDesSelectorType=").Append(Extension.KeySerDesSelectorType).Append(' ');
                     builder.Append("ValueSerDesSelectorType=").Append(Extension.ValueSerDesSelectorType).Append(' ');
                     builder.Append("ValueContainerType=").Append(Extension.ValueContainerType).Append(' ');
-                    builder.Append("TopicPrefix=").Append(Extension.TopicPrefix).Append(' ');
-                    builder.Append("ApplicationId=").Append(Extension.ApplicationId).Append(' ');
-                    builder.Append("BootstrapServers=").Append(Extension.BootstrapServers).Append(' ');
-                    builder.Append("UseDeletePolicyForTopic=").Append(Extension.UseDeletePolicyForTopic).Append(' ');
-                    builder.Append("UseCompactedReplicator=").Append(Extension.UseCompactedReplicator).Append(' ');
-                    builder.Append("UseKNetStreams=").Append(Extension.UseKNetStreams).Append(' ');
-                    builder.Append("UseGlobalTable=").Append(Extension.UseGlobalTable).Append(' ');
-                    builder.Append("UsePersistentStorage=").Append(Extension.UsePersistentStorage).Append(' ');
-                    builder.Append("UseEnumeratorWithPrefetch=").Append(Extension.UseEnumeratorWithPrefetch).Append(' ');
                     builder.Append("UseByteBufferDataTransfer=").Append(Extension.UseByteBufferDataTransfer).Append(' ');
+                    builder.Append("BootstrapServers=").Append(Extension.BootstrapServers).Append(' ');
+                    builder.Append("UseKNetStreams=").Append(Extension.UseKNetStreams).Append(' ');
+                    builder.Append("UsePersistentStorage=").Append(Extension.UsePersistentStorage).Append(' ');
+                    builder.Append("UseCompactedReplicator=").Append(Extension.UseCompactedReplicator).Append(' ');
+                    builder.Append("UseDeletePolicyForTopic=").Append(Extension.UseDeletePolicyForTopic).Append(' ');
                     builder.Append("DefaultNumPartitions=").Append(Extension.DefaultNumPartitions).Append(' ');
                     builder.Append("DefaultReplicationFactor=").Append(Extension.DefaultReplicationFactor).Append(' ');
+                    // context
                     builder.Append("DefaultConsumerInstances=").Append(Extension.DefaultConsumerInstances).Append(' ');
                     builder.Append("ConsumerConfig=").Append(Extension.ConsumerConfig?.ToString()).Append(' ');
-                    builder.Append("ProducerConfig=").Append(Extension.ProducerConfig?.ToString()).Append(' ');
-                    builder.Append("StreamsConfig=").Append(Extension.StreamsConfig?.ToString()).Append(' ');
-                    builder.Append("TopicConfig=").Append(Extension.TopicConfig?.ToString()).Append(' ');
+                    builder.Append("TopicPrefix=").Append(Extension.TopicPrefix).Append(' ');
+                    builder.Append("ApplicationId=").Append(Extension.ApplicationId).Append(' ');
                     builder.Append("ManageEvents=").Append(Extension.ManageEvents).Append(' ');
                     builder.Append("ReadOnlyMode=").Append(Extension.ReadOnlyMode).Append(' ');
                     builder.Append("DefaultSynchronizationTimeout=").Append(Extension.DefaultSynchronizationTimeout).Append(' ');
+                    builder.Append("UseEnumeratorWithPrefetch=").Append(Extension.UseEnumeratorWithPrefetch).Append(' ');
                     builder.Append("UseStorePrefixScan=").Append(Extension.UseStorePrefixScan).Append(' ');
                     builder.Append("UseStoreSingleKeyLookup=").Append(Extension.UseStoreSingleKeyLookup).Append(' ');
                     builder.Append("UseStoreKeyRange=").Append(Extension.UseStoreKeyRange).Append(' ');
                     builder.Append("UseStoreReverse=").Append(Extension.UseStoreReverse).Append(' ');
                     builder.Append("UseStoreReverseKeyRange=").Append(Extension.UseStoreReverseKeyRange).Append(' ');
+                    builder.Append("UseGlobalTable=").Append(Extension.UseGlobalTable).Append(' ');
                     _logFragment = builder.ToString();
                 }
-
                 return _logFragment;
             }
         }
 
+        // ClusterId + singleton options che cambiano i servizi nel SP
         public override int GetServiceProviderHashCode()
-            => Extension.ClusterId?.GetHashCode() ?? 0;
+        {
+            var hash = new HashCode();
+            hash.Add(Extension.ClusterId);
+            hash.Add(Extension.KeySerDesSelectorType);
+            hash.Add(Extension.ValueSerDesSelectorType);
+            hash.Add(Extension.ValueContainerType);
+            hash.Add(Extension.UseByteBufferDataTransfer);
+            hash.Add(Extension.UseKNetStreams);
+            hash.Add(Extension.UsePersistentStorage);
+            hash.Add(Extension.UseCompactedReplicator);
+            return hash.ToHashCode();
+        }
 
         public override bool ShouldUseSameServiceProvider(DbContextOptionsExtensionInfo other)
-            => other is ExtensionInfo otherInfo
-                && Extension.ClusterId == otherInfo.Extension.ClusterId;
+            => other is ExtensionInfo o
+            && Extension.ClusterId == o.Extension.ClusterId
+            && Extension.KeySerDesSelectorType == o.Extension.KeySerDesSelectorType
+            && Extension.ValueSerDesSelectorType == o.Extension.ValueSerDesSelectorType
+            && Extension.ValueContainerType == o.Extension.ValueContainerType
+            && Extension.UseByteBufferDataTransfer == o.Extension.UseByteBufferDataTransfer
+            && Extension.UseKNetStreams == o.Extension.UseKNetStreams
+            && Extension.UsePersistentStorage == o.Extension.UsePersistentStorage
+            && Extension.UseCompactedReplicator == o.Extension.UseCompactedReplicator;
 
         public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
-            => debugInfo["KEFCore:ClusterId"]
-                = (Extension.ClusterId?.GetHashCode() ?? 0).ToString(CultureInfo.InvariantCulture);
+        {
+            debugInfo["KEFCore:ClusterId"] = (Extension.ClusterId?.GetHashCode() ?? 0).ToString(CultureInfo.InvariantCulture);
+            debugInfo["KEFCore:UseKNetStreams"] = Extension.UseKNetStreams.ToString();
+            debugInfo["KEFCore:UsePersistentStorage"] = Extension.UsePersistentStorage.ToString();
+            debugInfo["KEFCore:ApplicationId"] = Extension.ApplicationId ?? "(none)";
+            debugInfo["KEFCore:TopicPrefix"] = Extension.TopicPrefix ?? "(none)";
+        }
     }
+
+    #endregion
 }

--- a/src/net/KEFCore/Infrastructure/Internal/KEFCoreOptionsExtension.cs
+++ b/src/net/KEFCore/Infrastructure/Internal/KEFCoreOptionsExtension.cs
@@ -61,7 +61,8 @@ public class KEFCoreOptionsExtension : IDbContextOptionsExtension, IKEFCoreSingl
         KeySerDesSelectorType = copyFrom.KeySerDesSelectorType;
         ValueSerDesSelectorType = copyFrom.ValueSerDesSelectorType;
         ValueContainerType = copyFrom.ValueContainerType;
-        UseByteBufferDataTransfer = copyFrom.UseByteBufferDataTransfer;
+        UseKeyByteBufferDataTransfer = copyFrom.UseKeyByteBufferDataTransfer;
+        UseValueContainerByteBufferDataTransfer = copyFrom.UseValueContainerByteBufferDataTransfer;
         BootstrapServers = copyFrom.BootstrapServers;
         UseKNetStreams = copyFrom.UseKNetStreams;
         UsePersistentStorage = copyFrom.UsePersistentStorage;
@@ -118,8 +119,10 @@ public class KEFCoreOptionsExtension : IDbContextOptionsExtension, IKEFCoreSingl
     public virtual Type ValueSerDesSelectorType { get; set; } = DefaultKEFCoreSerDes.DefaultValueContainerSerialization;
     /// <inheritdoc cref="KEFCoreDbContext.ValueContainerType"/>
     public virtual Type ValueContainerType { get; set; } = DefaultKEFCoreSerDes.DefaultValueContainer;
-    /// <inheritdoc cref="KEFCoreDbContext.UseByteBufferDataTransfer"/>
-    public virtual bool UseByteBufferDataTransfer { get; set; } = false;
+    /// <inheritdoc cref="KEFCoreDbContext.UseKeyByteBufferDataTransfer"/>
+    public virtual bool UseKeyByteBufferDataTransfer { get; set; } = false;
+    /// <inheritdoc cref="KEFCoreDbContext.UseValueContainerByteBufferDataTransfer"/>
+    public virtual bool UseValueContainerByteBufferDataTransfer { get; set; } = false;
     /// <inheritdoc cref="KEFCoreDbContext.BootstrapServers"/>
     public virtual string? BootstrapServers { get; set; }
     /// <inheritdoc cref="KEFCoreDbContext.UseKNetStreams"/>
@@ -137,7 +140,7 @@ public class KEFCoreOptionsExtension : IDbContextOptionsExtension, IKEFCoreSingl
     public virtual short DefaultReplicationFactor { get; set; } = 1;
     /// <inheritdoc cref="KEFCoreDbContext.TopicConfig"/>
     public virtual TopicConfigBuilder? TopicConfig { get; set; }
-    // explicit per il mismatch short/int nell'interfaccia
+    // explicit for mismatch short/int in the interface
     int IKEFCoreSingletonOptions.DefaultReplicationFactor => DefaultReplicationFactor;
 
     // ── Context-only options ──────────────────────────────────────────────
@@ -205,11 +208,18 @@ public class KEFCoreOptionsExtension : IDbContextOptionsExtension, IKEFCoreSingl
         clone.ValueContainerType = serializationType;
         return clone;
     }
-    /// <inheritdoc cref="KEFCoreDbContext.UseByteBufferDataTransfer"/>
-    public virtual KEFCoreOptionsExtension WithByteBufferDataTransfer(bool useByteBufferDataTransfer = true)
+    /// <inheritdoc cref="KEFCoreDbContext.UseKeyByteBufferDataTransfer"/>
+    public virtual KEFCoreOptionsExtension WithKeyByteBufferDataTransfer(bool useKeyByteBufferDataTransfer = true)
     {
         var clone = Clone();
-        clone.UseByteBufferDataTransfer = useByteBufferDataTransfer;
+        clone.UseKeyByteBufferDataTransfer = useKeyByteBufferDataTransfer;
+        return clone;
+    }
+    /// <inheritdoc cref="KEFCoreDbContext.UseValueContainerByteBufferDataTransfer"/>
+    public virtual KEFCoreOptionsExtension WithValueContainerByteBufferDataTransfer(bool useValueContainerByteBufferDataTransfer = true)
+    {
+        var clone = Clone();
+        clone.UseValueContainerByteBufferDataTransfer = useValueContainerByteBufferDataTransfer;
         return clone;
     }
     /// <inheritdoc cref="KEFCoreDbContext.BootstrapServers"/>
@@ -405,10 +415,10 @@ public class KEFCoreOptionsExtension : IDbContextOptionsExtension, IKEFCoreSingl
         string baSerdesName = Class.ClassNameOf<Org.Apache.Kafka.Common.Serialization.Serdes.ByteArraySerde>();
         string bbSerdesName = Class.ClassNameOf<MASES.KNet.Serialization.Serdes.ByteBufferSerde>();
 
-        builder.DefaultKeySerdeClass = this.JVMKeyType(entityType) == typeof(byte[]) ? Class.ForName(baSerdesName, true, Class.SystemClassLoader)
-                                                                                     : Class.ForName(bbSerdesName, true, Class.SystemClassLoader);
-        builder.DefaultValueSerdeClass = this.JVMValueContainerType(entityType) == typeof(byte[]) ? Class.ForName(baSerdesName, true, Class.SystemClassLoader)
-                                                                                                  : Class.ForName(bbSerdesName, true, Class.SystemClassLoader);
+        builder.DefaultKeySerdeClass = !UseKeyByteBufferDataTransfer ? Class.ForName(baSerdesName, true, Class.SystemClassLoader)
+                                                                     : Class.ForName(bbSerdesName, true, Class.SystemClassLoader);
+        builder.DefaultValueSerdeClass = !UseValueContainerByteBufferDataTransfer ? Class.ForName(baSerdesName, true, Class.SystemClassLoader)
+                                                                                  : Class.ForName(bbSerdesName, true, Class.SystemClassLoader);
         builder.DSLStoreSuppliersClass = UsePersistentStorage ? Class.ForName(Class.ClassNameOf<BuiltInDslStoreSuppliers.RocksDBDslStoreSuppliers>(), true, Class.SystemClassLoader)
                                                               : Class.ForName(Class.ClassNameOf<BuiltInDslStoreSuppliers.InMemoryDslStoreSuppliers>(), true, Class.SystemClassLoader);
 
@@ -551,7 +561,8 @@ public class KEFCoreOptionsExtension : IDbContextOptionsExtension, IKEFCoreSingl
             || other.KeySerDesSelectorType != KeySerDesSelectorType
             || other.ValueSerDesSelectorType != ValueSerDesSelectorType
             || other.ValueContainerType != ValueContainerType
-            || other.UseByteBufferDataTransfer != UseByteBufferDataTransfer
+            || other.UseKeyByteBufferDataTransfer != UseKeyByteBufferDataTransfer
+            || other.UseValueContainerByteBufferDataTransfer != UseValueContainerByteBufferDataTransfer
             || other.UseKNetStreams != UseKNetStreams
             || other.UsePersistentStorage != UsePersistentStorage
             || other.UseCompactedReplicator != UseCompactedReplicator)
@@ -584,7 +595,8 @@ public class KEFCoreOptionsExtension : IDbContextOptionsExtension, IKEFCoreSingl
                     builder.Append("KeySerDesSelectorType=").Append(Extension.KeySerDesSelectorType).Append(' ');
                     builder.Append("ValueSerDesSelectorType=").Append(Extension.ValueSerDesSelectorType).Append(' ');
                     builder.Append("ValueContainerType=").Append(Extension.ValueContainerType).Append(' ');
-                    builder.Append("UseByteBufferDataTransfer=").Append(Extension.UseByteBufferDataTransfer).Append(' ');
+                    builder.Append("UseKeyByteBufferDataTransfer=").Append(Extension.UseKeyByteBufferDataTransfer).Append(' ');
+                    builder.Append("UseValueContainerByteBufferDataTransfer=").Append(Extension.UseValueContainerByteBufferDataTransfer).Append(' ');
                     builder.Append("BootstrapServers=").Append(Extension.BootstrapServers).Append(' ');
                     builder.Append("UseKNetStreams=").Append(Extension.UseKNetStreams).Append(' ');
                     builder.Append("UsePersistentStorage=").Append(Extension.UsePersistentStorage).Append(' ');
@@ -621,7 +633,8 @@ public class KEFCoreOptionsExtension : IDbContextOptionsExtension, IKEFCoreSingl
             hash.Add(Extension.KeySerDesSelectorType);
             hash.Add(Extension.ValueSerDesSelectorType);
             hash.Add(Extension.ValueContainerType);
-            hash.Add(Extension.UseByteBufferDataTransfer);
+            hash.Add(Extension.UseKeyByteBufferDataTransfer);
+            hash.Add(Extension.UseValueContainerByteBufferDataTransfer);
             hash.Add(Extension.UseKNetStreams);
             hash.Add(Extension.UsePersistentStorage);
             hash.Add(Extension.UseCompactedReplicator);
@@ -634,7 +647,8 @@ public class KEFCoreOptionsExtension : IDbContextOptionsExtension, IKEFCoreSingl
             && Extension.KeySerDesSelectorType == o.Extension.KeySerDesSelectorType
             && Extension.ValueSerDesSelectorType == o.Extension.ValueSerDesSelectorType
             && Extension.ValueContainerType == o.Extension.ValueContainerType
-            && Extension.UseByteBufferDataTransfer == o.Extension.UseByteBufferDataTransfer
+            && Extension.UseKeyByteBufferDataTransfer == o.Extension.UseKeyByteBufferDataTransfer
+            && Extension.UseValueContainerByteBufferDataTransfer == o.Extension.UseValueContainerByteBufferDataTransfer
             && Extension.UseKNetStreams == o.Extension.UseKNetStreams
             && Extension.UsePersistentStorage == o.Extension.UsePersistentStorage
             && Extension.UseCompactedReplicator == o.Extension.UseCompactedReplicator;

--- a/src/net/KEFCore/Infrastructure/Internal/KEFCoreSingletonOptions.cs
+++ b/src/net/KEFCore/Infrastructure/Internal/KEFCoreSingletonOptions.cs
@@ -18,9 +18,6 @@
 
 using MASES.EntityFrameworkCore.KNet.Extensions;
 using MASES.KNet.Common;
-using MASES.KNet.Consumer;
-using MASES.KNet.Producer;
-using MASES.KNet.Streams;
 
 namespace MASES.EntityFrameworkCore.KNet.Infrastructure.Internal;
 /// <summary>
@@ -31,34 +28,45 @@ namespace MASES.EntityFrameworkCore.KNet.Infrastructure.Internal;
 /// </summary>
 public class KEFCoreSingletonOptions : IKEFCoreSingletonOptions
 {
+    private string? _clusterId;
+
     /// <inheritdoc/>
     public virtual void Initialize(IDbContextOptions options)
     {
         var kefcoreOptions = options.FindExtension<KEFCoreOptionsExtension>();
+        if (kefcoreOptions == null) return;
 
-        if (kefcoreOptions != null)
-        {
-            KeySerDesSelectorType = kefcoreOptions.KeySerDesSelectorType;
-            ValueSerDesSelectorType = kefcoreOptions.ValueSerDesSelectorType;
-            ValueContainerType = kefcoreOptions.ValueContainerType;
-            BootstrapServers = kefcoreOptions.BootstrapServers;
-            UseDeletePolicyForTopic = kefcoreOptions.UseDeletePolicyForTopic;
-            UseCompactedReplicator = kefcoreOptions.UseCompactedReplicator;
-            UseKNetStreams = kefcoreOptions.UseKNetStreams;
-            UsePersistentStorage = kefcoreOptions.UsePersistentStorage;
-            UseByteBufferDataTransfer = kefcoreOptions.UseByteBufferDataTransfer;
-            DefaultNumPartitions = kefcoreOptions.DefaultNumPartitions;
-            DefaultReplicationFactor = kefcoreOptions.DefaultReplicationFactor;
-            TopicConfig = TopicConfigBuilder.CreateFrom(kefcoreOptions.TopicConfig);
-        }
+        // risolve e salva ClusterId una volta sola
+        _clusterId = kefcoreOptions.ClusterId;
+
+        KeySerDesSelectorType = kefcoreOptions.KeySerDesSelectorType;
+        ValueSerDesSelectorType = kefcoreOptions.ValueSerDesSelectorType;
+        ValueContainerType = kefcoreOptions.ValueContainerType;
+        BootstrapServers = kefcoreOptions.BootstrapServers;  // tenuto per reference/logging
+        UseByteBufferDataTransfer = kefcoreOptions.UseByteBufferDataTransfer;
+        UseKNetStreams = kefcoreOptions.UseKNetStreams;
+        UsePersistentStorage = kefcoreOptions.UsePersistentStorage;
+        UseCompactedReplicator = kefcoreOptions.UseCompactedReplicator;
+        // non-hash singleton (first-wins)
+        UseDeletePolicyForTopic = kefcoreOptions.UseDeletePolicyForTopic;
+        DefaultNumPartitions = kefcoreOptions.DefaultNumPartitions;
+        DefaultReplicationFactor = kefcoreOptions.DefaultReplicationFactor;
+        TopicConfig = TopicConfigBuilder.CreateFrom(kefcoreOptions.TopicConfig);
     }
     /// <inheritdoc/>
     public virtual void Validate(IDbContextOptions options)
     {
         var kefcoreOptions = options.FindExtension<KEFCoreOptionsExtension>();
+        if (kefcoreOptions == null) return;
 
-        if (kefcoreOptions != null
-            && BootstrapServers != kefcoreOptions.BootstrapServers)
+        if (kefcoreOptions.ClusterId != _clusterId
+            || kefcoreOptions.KeySerDesSelectorType != KeySerDesSelectorType
+            || kefcoreOptions.ValueSerDesSelectorType != ValueSerDesSelectorType
+            || kefcoreOptions.ValueContainerType != ValueContainerType
+            || kefcoreOptions.UseByteBufferDataTransfer != UseByteBufferDataTransfer
+            || kefcoreOptions.UseKNetStreams != UseKNetStreams
+            || kefcoreOptions.UsePersistentStorage != UsePersistentStorage
+            || kefcoreOptions.UseCompactedReplicator != UseCompactedReplicator)
         {
             throw new InvalidOperationException(
                 CoreStrings.SingletonOptionChanged(
@@ -77,7 +85,7 @@ public class KEFCoreSingletonOptions : IKEFCoreSingletonOptions
     /// <inheritdoc/>
     public virtual bool UseDeletePolicyForTopic { get; private set; }
     /// <inheritdoc/>
-    [Obsolete("Option will be removed soon")] 
+    [Obsolete("Option will be removed soon")]
     public virtual bool UseCompactedReplicator { get; private set; }
     /// <inheritdoc/>
     public virtual bool UseKNetStreams { get; private set; }

--- a/src/net/KEFCore/Infrastructure/Internal/KEFCoreSingletonOptions.cs
+++ b/src/net/KEFCore/Infrastructure/Internal/KEFCoreSingletonOptions.cs
@@ -16,6 +16,7 @@
 *  Refer to LICENSE for more information.
 */
 
+using MASES.EntityFrameworkCore.KNet.Extensions;
 using MASES.KNet.Common;
 using MASES.KNet.Consumer;
 using MASES.KNet.Producer;
@@ -40,26 +41,15 @@ public class KEFCoreSingletonOptions : IKEFCoreSingletonOptions
             KeySerDesSelectorType = kefcoreOptions.KeySerDesSelectorType;
             ValueSerDesSelectorType = kefcoreOptions.ValueSerDesSelectorType;
             ValueContainerType = kefcoreOptions.ValueContainerType;
-            TopicPrefix = kefcoreOptions.TopicPrefix;
-            ApplicationId = kefcoreOptions.ApplicationId;
             BootstrapServers = kefcoreOptions.BootstrapServers;
             UseDeletePolicyForTopic = kefcoreOptions.UseDeletePolicyForTopic;
             UseCompactedReplicator = kefcoreOptions.UseCompactedReplicator;
             UseKNetStreams = kefcoreOptions.UseKNetStreams;
-            UseGlobalTable = kefcoreOptions.UseGlobalTable;
             UsePersistentStorage = kefcoreOptions.UsePersistentStorage;
-            UseEnumeratorWithPrefetch = kefcoreOptions.UseEnumeratorWithPrefetch;
             UseByteBufferDataTransfer = kefcoreOptions.UseByteBufferDataTransfer;
             DefaultNumPartitions = kefcoreOptions.DefaultNumPartitions;
-            DefaultConsumerInstances = kefcoreOptions.DefaultConsumerInstances;
             DefaultReplicationFactor = kefcoreOptions.DefaultReplicationFactor;
-            ConsumerConfig = ConsumerConfigBuilder.CreateFrom(kefcoreOptions.ConsumerConfig);
-            ProducerConfig = ProducerConfigBuilder.CreateFrom(kefcoreOptions.ProducerConfig);
-            StreamsConfig = StreamsConfigBuilder.CreateFrom(kefcoreOptions.StreamsConfig);
             TopicConfig = TopicConfigBuilder.CreateFrom(kefcoreOptions.TopicConfig);
-            ManageEvents = kefcoreOptions.ManageEvents;
-            ReadOnlyMode = kefcoreOptions.ReadOnlyMode;
-            DefaultSynchronizationTimeout = kefcoreOptions.DefaultSynchronizationTimeout;
         }
     }
     /// <inheritdoc/>
@@ -83,10 +73,6 @@ public class KEFCoreSingletonOptions : IKEFCoreSingletonOptions
     /// <inheritdoc/>
     public virtual Type? ValueContainerType { get; private set; }
     /// <inheritdoc/>
-    public virtual string? TopicPrefix { get; private set; }
-    /// <inheritdoc/>
-    public virtual string? ApplicationId { get; private set; }
-    /// <inheritdoc/>
     public virtual string? BootstrapServers { get; private set; }
     /// <inheritdoc/>
     public virtual bool UseDeletePolicyForTopic { get; private set; }
@@ -96,31 +82,13 @@ public class KEFCoreSingletonOptions : IKEFCoreSingletonOptions
     /// <inheritdoc/>
     public virtual bool UseKNetStreams { get; private set; }
     /// <inheritdoc/>
-    public virtual bool UseGlobalTable { get; private set; }
-    /// <inheritdoc/>
     public virtual bool UsePersistentStorage { get; private set; }
-    /// <inheritdoc/>
-    public virtual bool UseEnumeratorWithPrefetch { get; private set; }
     /// <inheritdoc/>
     public virtual bool UseByteBufferDataTransfer { get; private set; }
     /// <inheritdoc/>
     public virtual int DefaultNumPartitions { get; private set; }
     /// <inheritdoc/>
-    public virtual int? DefaultConsumerInstances { get; private set; }
-    /// <inheritdoc/>
     public virtual int DefaultReplicationFactor { get; private set; }
     /// <inheritdoc/>
-    public virtual ConsumerConfigBuilder? ConsumerConfig { get; private set; }
-    /// <inheritdoc/>
-    public virtual ProducerConfigBuilder? ProducerConfig { get; private set; }
-    /// <inheritdoc/>
-    public virtual StreamsConfigBuilder? StreamsConfig { get; private set; }
-    /// <inheritdoc/>
     public virtual TopicConfigBuilder? TopicConfig { get; private set; }
-    /// <inheritdoc/>
-    public virtual bool ManageEvents { get; private set; }
-    /// <inheritdoc/>
-    public virtual bool ReadOnlyMode { get; private set; }
-    /// <inheritdoc/>
-    public virtual long DefaultSynchronizationTimeout { get; private set; }
 }

--- a/src/net/KEFCore/Infrastructure/Internal/KEFCoreSingletonOptions.cs
+++ b/src/net/KEFCore/Infrastructure/Internal/KEFCoreSingletonOptions.cs
@@ -36,14 +36,14 @@ public class KEFCoreSingletonOptions : IKEFCoreSingletonOptions
         var kefcoreOptions = options.FindExtension<KEFCoreOptionsExtension>();
         if (kefcoreOptions == null) return;
 
-        // risolve e salva ClusterId una volta sola
         _clusterId = kefcoreOptions.ClusterId;
 
         KeySerDesSelectorType = kefcoreOptions.KeySerDesSelectorType;
         ValueSerDesSelectorType = kefcoreOptions.ValueSerDesSelectorType;
         ValueContainerType = kefcoreOptions.ValueContainerType;
-        BootstrapServers = kefcoreOptions.BootstrapServers;  // tenuto per reference/logging
-        UseByteBufferDataTransfer = kefcoreOptions.UseByteBufferDataTransfer;
+        BootstrapServers = kefcoreOptions.BootstrapServers;
+        UseKeyByteBufferDataTransfer = kefcoreOptions.UseKeyByteBufferDataTransfer;
+        UseValueContainerByteBufferDataTransfer = kefcoreOptions.UseValueContainerByteBufferDataTransfer;
         UseKNetStreams = kefcoreOptions.UseKNetStreams;
         UsePersistentStorage = kefcoreOptions.UsePersistentStorage;
         UseCompactedReplicator = kefcoreOptions.UseCompactedReplicator;
@@ -63,7 +63,8 @@ public class KEFCoreSingletonOptions : IKEFCoreSingletonOptions
             || kefcoreOptions.KeySerDesSelectorType != KeySerDesSelectorType
             || kefcoreOptions.ValueSerDesSelectorType != ValueSerDesSelectorType
             || kefcoreOptions.ValueContainerType != ValueContainerType
-            || kefcoreOptions.UseByteBufferDataTransfer != UseByteBufferDataTransfer
+            || kefcoreOptions.UseKeyByteBufferDataTransfer != UseKeyByteBufferDataTransfer
+            || kefcoreOptions.UseValueContainerByteBufferDataTransfer != UseValueContainerByteBufferDataTransfer
             || kefcoreOptions.UseKNetStreams != UseKNetStreams
             || kefcoreOptions.UsePersistentStorage != UsePersistentStorage
             || kefcoreOptions.UseCompactedReplicator != UseCompactedReplicator)
@@ -92,7 +93,9 @@ public class KEFCoreSingletonOptions : IKEFCoreSingletonOptions
     /// <inheritdoc/>
     public virtual bool UsePersistentStorage { get; private set; }
     /// <inheritdoc/>
-    public virtual bool UseByteBufferDataTransfer { get; private set; }
+    public virtual bool UseKeyByteBufferDataTransfer { get; private set; }
+    /// <inheritdoc/>
+    public virtual bool UseValueContainerByteBufferDataTransfer { get; private set; }
     /// <inheritdoc/>
     public virtual int DefaultNumPartitions { get; private set; }
     /// <inheritdoc/>

--- a/src/net/KEFCore/Infrastructure/KEFCoreDbContext.cs
+++ b/src/net/KEFCore/Infrastructure/KEFCoreDbContext.cs
@@ -196,6 +196,7 @@ public class KEFCoreDbContext : DbContext
     /// coming from other configuration parameters like <see cref="ApplicationId"/>: using the same <see cref="ApplicationId"/> across the same cluster, the partitions of <see cref="Org.Apache.Kafka.Streams.Kstream.KTable{K, V}"/> (<see cref="MASES.KNet.Streams.Kstream.KTable{K, V, TJVMK, TJVMV}"/> if <see cref="UseKNetStreams"/> is <see langword="true"/>)
     /// are managed from multiple instances.
     /// </remarks>
+    [Obsolete("ApplicationId must be unique per process — UseGlobalTable is no longer needed.")] 
     public virtual bool UseGlobalTable { get; set; } = false;
     /// <summary>
     /// The optional <see cref="ConsumerConfigBuilder"/> used when <see cref="UseCompactedReplicator"/> is <see langword="true"/>

--- a/src/net/KEFCore/Infrastructure/KEFCoreDbContext.cs
+++ b/src/net/KEFCore/Infrastructure/KEFCoreDbContext.cs
@@ -170,9 +170,13 @@ public class KEFCoreDbContext : DbContext
     /// <remarks>Used only if <see cref="UseCompactedReplicator"/> is <see langword="false"/> and <see cref="UseKNetStreams"/> is <see langword="true"/>, not available in EFCore 6.</remarks>
     public virtual bool UseEnumeratorWithPrefetch { get; set; } = false;
     /// <summary>
-    /// Setting this property to <see langword="true"/> the engine prefers to use <see cref="Java.Nio.ByteBuffer"/> data exchange in serializer instances
+    /// Setting this property to <see langword="true"/> the engine prefers to use <see cref="Java.Nio.ByteBuffer"/> data exchange in serializer instances for the key
     /// </summary>
-    public virtual bool UseByteBufferDataTransfer { get; set; } = false;
+    public virtual bool UseKeyByteBufferDataTransfer { get; set; } = false;
+    /// <summary>
+    /// Setting this property to <see langword="true"/> the engine prefers to use <see cref="Java.Nio.ByteBuffer"/> data exchange in serializer instances for value buffer
+    /// </summary>
+    public virtual bool UseValueContainerByteBufferDataTransfer { get; set; } = false;
     /// <summary>
     /// Use <see href="https://kafka.apache.org/documentation/#topicconfigs_cleanup.policy">delete cleanup policy</see> when a topic is created
     /// </summary>
@@ -322,7 +326,8 @@ public class KEFCoreDbContext : DbContext
             o.WithTopicPrefix(TopicPrefix);
             o.WithPersistentStorage(UsePersistentStorage);
             o.WithEnumeratorWithPrefetch(UseEnumeratorWithPrefetch);
-            o.WithByteBufferDataTransfer(UseByteBufferDataTransfer);
+            o.WithKeyByteBufferDataTransfer(UseKeyByteBufferDataTransfer);
+            o.WithValueContainerByteBufferDataTransfer(UseValueContainerByteBufferDataTransfer);
             o.WithDeletePolicyForTopic(UseDeletePolicyForTopic);
             o.WithCompactedReplicator(UseCompactedReplicator);
             o.WithKNetStreams(UseKNetStreams);

--- a/src/net/KEFCore/Infrastructure/KEFCoreDbContext.cs
+++ b/src/net/KEFCore/Infrastructure/KEFCoreDbContext.cs
@@ -18,6 +18,7 @@
 
 // #define DEBUG_PERFORMANCE
 
+using MASES.EntityFrameworkCore.KNet.Extensions;
 using MASES.EntityFrameworkCore.KNet.Serialization;
 using MASES.EntityFrameworkCore.KNet.Serialization.Json;
 using MASES.EntityFrameworkCore.KNet.Serialization.Json.Storage;
@@ -157,6 +158,7 @@ public class KEFCoreDbContext : DbContext
     /// <summary>
     /// Default consumr instances used in conjunction with <see cref="UseCompactedReplicator"/>
     /// </summary>
+    [Obsolete("Option will be removed soon")] 
     public virtual int? DefaultConsumerInstances { get; set; } = null;
     /// <summary>
     /// Use persistent storage when Apache Kafka™ Streams is in use
@@ -317,13 +319,13 @@ public class KEFCoreDbContext : DbContext
             o.WithStreamsConfig(StreamsConfig ?? DefaultStreamsConfig).WithDefaultNumPartitions(DefaultNumPartitions);
             o.WithTopicConfig(TopicConfig ?? DefaultTopicConfig);
             o.WithTopicPrefix(TopicPrefix);
-            o.WithUsePersistentStorage(UsePersistentStorage);
-            o.WithUseEnumeratorWithPrefetch(UseEnumeratorWithPrefetch);
-            o.WithUseByteBufferDataTransfer(UseByteBufferDataTransfer);
-            o.WithUseDeletePolicyForTopic(UseDeletePolicyForTopic);
+            o.WithPersistentStorage(UsePersistentStorage);
+            o.WithEnumeratorWithPrefetch(UseEnumeratorWithPrefetch);
+            o.WithByteBufferDataTransfer(UseByteBufferDataTransfer);
+            o.WithDeletePolicyForTopic(UseDeletePolicyForTopic);
             o.WithCompactedReplicator(UseCompactedReplicator);
-            o.WithUseKNetStreams(UseKNetStreams);
-            o.WithUseGlobalTable(UseGlobalTable);
+            o.WithKNetStreams(UseKNetStreams);
+            o.WithGlobalTable(UseGlobalTable);
             o.WithDefaultReplicationFactor(DefaultReplicationFactor);
             o.WithManageEvents(ManageEvents);
             o.WithDefaultSynchronizationTimeout(DefaultSynchronizationTimeout);

--- a/src/net/KEFCore/Infrastructure/KEFCoreDbContextOptionsBuilder.cs
+++ b/src/net/KEFCore/Infrastructure/KEFCoreDbContextOptionsBuilder.cs
@@ -17,7 +17,7 @@
 */
 
 using MASES.EntityFrameworkCore.KNet.Infrastructure.Internal;
-using MASES.EntityFrameworkCore.KNet.Storage;
+using MASES.EntityFrameworkCore.KNet.Extensions;
 using MASES.KNet.Common;
 using MASES.KNet.Consumer;
 using MASES.KNet.Producer;
@@ -37,7 +37,7 @@ namespace MASES.EntityFrameworkCore.KNet.Infrastructure;
 ///     <para>
 ///         Instances of this class are returned from a call to
 ///         <see
-///             cref="KEFCoreDbContextOptionsExtensions.UseKEFCore(DbContextOptionsBuilder, string, string, Action{KEFCoreDbContextOptionsBuilder}?)" />
+///             cref="KEFCoreDbContextOptionsExtensions.UseKEFCore(DbContextOptionsBuilder, string?, string, Action{MASES.EntityFrameworkCore.KNet.Infrastructure.KEFCoreDbContextOptionsBuilder}?)" />
 ///         and it is not designed to be directly constructed in your application code.
 ///     </para>
 ///     <para>
@@ -159,12 +159,12 @@ public class KEFCoreDbContextOptionsBuilder(DbContextOptionsBuilder optionsBuild
     /// </remarks>
     /// <param name="useDeletePolicyForTopic">If <see langword="true" />, then will be used <see href="https://kafka.apache.org/documentation/#topicconfigs_cleanup.policy">delete cleanup policy</see> when the topic is created the first time.</param>
     /// <returns>The same builder instance so that multiple calls can be chained.</returns>
-    public virtual KEFCoreDbContextOptionsBuilder WithUseDeletePolicyForTopic(bool useDeletePolicyForTopic = false)
+    public virtual KEFCoreDbContextOptionsBuilder WithDeletePolicyForTopic(bool useDeletePolicyForTopic = false)
     {
         var extension = OptionsBuilder.Options.FindExtension<KEFCoreOptionsExtension>()
             ?? new KEFCoreOptionsExtension();
 
-        extension = extension.WithUseDeletePolicyForTopic(useDeletePolicyForTopic);
+        extension = extension.WithDeletePolicyForTopic(useDeletePolicyForTopic);
 
         ((IDbContextOptionsBuilderInfrastructure)OptionsBuilder).AddOrUpdateExtension(extension);
 
@@ -202,12 +202,12 @@ public class KEFCoreDbContextOptionsBuilder(DbContextOptionsBuilder optionsBuild
     /// </remarks>
     /// <param name="useKNetStreams">If <see langword="true" /> then KNet version of Apache Kafka Streams will be used instead of standard Apache Kafka Streams.</param>
     /// <returns>The same builder instance so that multiple calls can be chained.</returns>
-    public virtual KEFCoreDbContextOptionsBuilder WithUseKNetStreams(bool useKNetStreams = false)
+    public virtual KEFCoreDbContextOptionsBuilder WithKNetStreams(bool useKNetStreams = false)
     {
         var extension = OptionsBuilder.Options.FindExtension<KEFCoreOptionsExtension>()
             ?? new KEFCoreOptionsExtension();
 
-        extension = extension.WithUseKNetStreams(useKNetStreams);
+        extension = extension.WithKNetStreams(useKNetStreams);
 
         ((IDbContextOptionsBuilderInfrastructure)OptionsBuilder).AddOrUpdateExtension(extension);
 
@@ -225,12 +225,12 @@ public class KEFCoreDbContextOptionsBuilder(DbContextOptionsBuilder optionsBuild
     /// </remarks>
     /// <param name="useGlobalTable">If <see langword="true" /> then <see cref="Org.Apache.Kafka.Streams.Kstream.GlobalKTable{K, V}"/> (<see cref="MASES.KNet.Streams.Kstream.GlobalKTable{K, V, TJVMK, TJVMV}"/> if <see cref="KEFCoreDbContext.UseKNetStreams"/> is <see langword="true" />.</param>
     /// <returns>The same builder instance so that multiple calls can be chained.</returns>
-    public virtual KEFCoreDbContextOptionsBuilder WithUseGlobalTable(bool useGlobalTable = false)
+    public virtual KEFCoreDbContextOptionsBuilder WithGlobalTable(bool useGlobalTable = false)
     {
         var extension = OptionsBuilder.Options.FindExtension<KEFCoreOptionsExtension>()
             ?? new KEFCoreOptionsExtension();
 
-        extension = extension.WithUseGlobalTable(useGlobalTable);
+        extension = extension.WithGlobalTable(useGlobalTable);
 
         ((IDbContextOptionsBuilderInfrastructure)OptionsBuilder).AddOrUpdateExtension(extension);
 
@@ -247,12 +247,12 @@ public class KEFCoreDbContextOptionsBuilder(DbContextOptionsBuilder optionsBuild
     /// </remarks>
     /// <param name="usePersistentStorage">If <see langword="true"/> the engine prefers to use enumerator instances able to do a prefetch on data speeding up execution</param>
     /// <returns>The same builder instance so that multiple calls can be chained.</returns>
-    public virtual KEFCoreDbContextOptionsBuilder WithUsePersistentStorage(bool usePersistentStorage = false)
+    public virtual KEFCoreDbContextOptionsBuilder WithPersistentStorage(bool usePersistentStorage = false)
     {
         var extension = OptionsBuilder.Options.FindExtension<KEFCoreOptionsExtension>()
             ?? new KEFCoreOptionsExtension();
 
-        extension = extension.WithUsePersistentStorage(usePersistentStorage);
+        extension = extension.WithPersistentStorage(usePersistentStorage);
 
         ((IDbContextOptionsBuilderInfrastructure)OptionsBuilder).AddOrUpdateExtension(extension);
 
@@ -269,12 +269,12 @@ public class KEFCoreDbContextOptionsBuilder(DbContextOptionsBuilder optionsBuild
     /// </remarks>
     /// <param name="useEnumeratorWithPrefetch">If <see langword="true" />, prefetch in enumeration will be used.</param>
     /// <returns>The same builder instance so that multiple calls can be chained.</returns>
-    public virtual KEFCoreDbContextOptionsBuilder WithUseEnumeratorWithPrefetch(bool useEnumeratorWithPrefetch = true)
+    public virtual KEFCoreDbContextOptionsBuilder WithEnumeratorWithPrefetch(bool useEnumeratorWithPrefetch = true)
     {
         var extension = OptionsBuilder.Options.FindExtension<KEFCoreOptionsExtension>()
             ?? new KEFCoreOptionsExtension();
 
-        extension = extension.WithUseEnumeratorWithPrefetch(useEnumeratorWithPrefetch);
+        extension = extension.WithEnumeratorWithPrefetch(useEnumeratorWithPrefetch);
 
         ((IDbContextOptionsBuilderInfrastructure)OptionsBuilder).AddOrUpdateExtension(extension);
 
@@ -290,12 +290,12 @@ public class KEFCoreDbContextOptionsBuilder(DbContextOptionsBuilder optionsBuild
     /// </remarks>
     /// <param name="useByteBufferDataTransfer">If <see langword="true" />, <see cref="Java.Nio.ByteBuffer"/> data exchange will be preferred.</param>
     /// <returns>The same builder instance so that multiple calls can be chained.</returns>
-    public virtual KEFCoreDbContextOptionsBuilder WithUseByteBufferDataTransfer(bool useByteBufferDataTransfer = true)
+    public virtual KEFCoreDbContextOptionsBuilder WithByteBufferDataTransfer(bool useByteBufferDataTransfer = true)
     {
         var extension = OptionsBuilder.Options.FindExtension<KEFCoreOptionsExtension>()
             ?? new KEFCoreOptionsExtension();
 
-        extension = extension.WithUseByteBufferDataTransfer(useByteBufferDataTransfer);
+        extension = extension.WithByteBufferDataTransfer(useByteBufferDataTransfer);
 
         ((IDbContextOptionsBuilderInfrastructure)OptionsBuilder).AddOrUpdateExtension(extension);
 
@@ -332,6 +332,7 @@ public class KEFCoreDbContextOptionsBuilder(DbContextOptionsBuilder optionsBuild
     /// </remarks>
     /// <param name="defaultConsumerInstances">The default number of consumer instances to be used in conjunction with <see cref="WithCompactedReplicator(bool)"/></param>
     /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    [Obsolete("Option will be removed soon")]
     public virtual KEFCoreDbContextOptionsBuilder WithDefaultConsumerInstances(int? defaultConsumerInstances = null)
     {
         var extension = OptionsBuilder.Options.FindExtension<KEFCoreOptionsExtension>()
@@ -374,6 +375,7 @@ public class KEFCoreDbContextOptionsBuilder(DbContextOptionsBuilder optionsBuild
     /// </remarks>
     /// <param name="consumerConfigBuilder">The <see cref="ConsumerConfigBuilder"/> where options are stored.</param>
     /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    [Obsolete("Option will be removed soon")]
     public virtual KEFCoreDbContextOptionsBuilder WithConsumerConfig(ConsumerConfigBuilder consumerConfigBuilder)
     {
         var extension = OptionsBuilder.Options.FindExtension<KEFCoreOptionsExtension>()

--- a/src/net/KEFCore/Infrastructure/KEFCoreDbContextOptionsBuilder.cs
+++ b/src/net/KEFCore/Infrastructure/KEFCoreDbContextOptionsBuilder.cs
@@ -282,20 +282,41 @@ public class KEFCoreDbContextOptionsBuilder(DbContextOptionsBuilder optionsBuild
     }
 
     /// <summary>
-    ///     Setting this property to <see langword="true"/> the engine prefers to use <see cref="Java.Nio.ByteBuffer"/> data exchange in serializer instances
+    ///     Setting this property to <see langword="true"/> the engine prefers to use <see cref="Java.Nio.ByteBuffer"/> data exchange in serializer instances for key
     /// </summary>
     /// <remarks>
     ///     See <see href="https://aka.ms/efcore-docs-dbcontext-options">Using DbContextOptions</see>, and
     ///     <see href="https://github.com/masesgroup/KEFCore">The EF Core Kafka database provider</see> for more information and examples.
     /// </remarks>
-    /// <param name="useByteBufferDataTransfer">If <see langword="true" />, <see cref="Java.Nio.ByteBuffer"/> data exchange will be preferred.</param>
+    /// <param name="useKeyByteBufferDataTransfer">If <see langword="true" />, <see cref="Java.Nio.ByteBuffer"/> data exchange will be preferred for key.</param>
     /// <returns>The same builder instance so that multiple calls can be chained.</returns>
-    public virtual KEFCoreDbContextOptionsBuilder WithByteBufferDataTransfer(bool useByteBufferDataTransfer = true)
+    public virtual KEFCoreDbContextOptionsBuilder WithKeyByteBufferDataTransfer(bool useKeyByteBufferDataTransfer = true)
     {
         var extension = OptionsBuilder.Options.FindExtension<KEFCoreOptionsExtension>()
             ?? new KEFCoreOptionsExtension();
 
-        extension = extension.WithByteBufferDataTransfer(useByteBufferDataTransfer);
+        extension = extension.WithKeyByteBufferDataTransfer(useKeyByteBufferDataTransfer);
+
+        ((IDbContextOptionsBuilderInfrastructure)OptionsBuilder).AddOrUpdateExtension(extension);
+
+        return this;
+    }
+
+    /// <summary>
+    ///     Setting this property to <see langword="true"/> the engine prefers to use <see cref="Java.Nio.ByteBuffer"/> data exchange in serializer instances for value container
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-dbcontext-options">Using DbContextOptions</see>, and
+    ///     <see href="https://github.com/masesgroup/KEFCore">The EF Core Kafka database provider</see> for more information and examples.
+    /// </remarks>
+    /// <param name="useValueContainerByteBufferDataTransfer">If <see langword="true" />, <see cref="Java.Nio.ByteBuffer"/> data exchange will be preferred for value container.</param>
+    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    public virtual KEFCoreDbContextOptionsBuilder WithValueContainerByteBufferDataTransfer(bool useValueContainerByteBufferDataTransfer = true)
+    {
+        var extension = OptionsBuilder.Options.FindExtension<KEFCoreOptionsExtension>()
+            ?? new KEFCoreOptionsExtension();
+
+        extension = extension.WithValueContainerByteBufferDataTransfer(useValueContainerByteBufferDataTransfer);
 
         ((IDbContextOptionsBuilderInfrastructure)OptionsBuilder).AddOrUpdateExtension(extension);
 

--- a/src/net/KEFCore/Metadata/Conventions/DefiningQueryRewritingConvention.cs
+++ b/src/net/KEFCore/Metadata/Conventions/DefiningQueryRewritingConvention.cs
@@ -19,6 +19,8 @@
 *  Refer to LICENSE for more information.
 */
 
+using MASES.EntityFrameworkCore.KNet.Extensions;
+
 namespace MASES.EntityFrameworkCore.KNet.Metadata.Conventions;
 
 /// <summary>

--- a/src/net/KEFCore/Metadata/Conventions/KEFCoreConventionSetBuilder.cs
+++ b/src/net/KEFCore/Metadata/Conventions/KEFCoreConventionSetBuilder.cs
@@ -19,6 +19,7 @@
 *  Refer to LICENSE for more information.
 */
 
+using MASES.EntityFrameworkCore.KNet.Extensions;
 using MASES.EntityFrameworkCore.KNet.Storage.Internal;
 
 namespace MASES.EntityFrameworkCore.KNet.Metadata.Conventions;

--- a/src/net/KEFCore/Storage/Internal/EntityTypeProducer.cs
+++ b/src/net/KEFCore/Storage/Internal/EntityTypeProducer.cs
@@ -21,6 +21,7 @@
 #nullable enable
 
 using Java.Util.Concurrent;
+using MASES.EntityFrameworkCore.KNet.Extensions;
 using MASES.EntityFrameworkCore.KNet.Serialization;
 using MASES.JCOBridge.C2JBridge;
 using MASES.KNet.Producer;

--- a/src/net/KEFCore/Storage/Internal/KEFCoreCluster.cs
+++ b/src/net/KEFCore/Storage/Internal/KEFCoreCluster.cs
@@ -23,6 +23,7 @@
 using Java.Util;
 using Java.Util.Concurrent;
 using MASES.EntityFrameworkCore.KNet.Diagnostics.Internal;
+using MASES.EntityFrameworkCore.KNet.Extensions;
 using MASES.EntityFrameworkCore.KNet.Infrastructure;
 using MASES.EntityFrameworkCore.KNet.Infrastructure.Internal;
 using MASES.EntityFrameworkCore.KNet.Serialization;

--- a/src/net/KEFCore/Storage/Internal/KEFCoreTableFactory.cs
+++ b/src/net/KEFCore/Storage/Internal/KEFCoreTableFactory.cs
@@ -17,6 +17,7 @@
 */
 
 using System.Collections.Concurrent;
+using MASES.EntityFrameworkCore.KNet.Extensions;
 using MASES.EntityFrameworkCore.KNet.Infrastructure.Internal;
 using MASES.EntityFrameworkCore.KNet.Serialization;
 

--- a/src/net/KEFCore/Storage/Internal/StreamsManager.cs
+++ b/src/net/KEFCore/Storage/Internal/StreamsManager.cs
@@ -22,6 +22,7 @@
 
 using Java.Lang;
 using Java.Util;
+using MASES.EntityFrameworkCore.KNet.Extensions;
 using MASES.KNet.Streams;
 using Org.Apache.Kafka.Streams;
 using System.Collections.Concurrent;

--- a/test/Common/ProgramConfig.cs
+++ b/test/Common/ProgramConfig.cs
@@ -101,7 +101,7 @@ namespace MASES.EntityFrameworkCore.KNet.Test.Common
         public bool UseCompactedReplicator { get; set; } = false;
         public bool UseKNetStreams { get; set; } = true;
         public bool UseEnumeratorWithPrefetch { get; set; } = true;
-        public bool UseByteBufferDataTransfer { get; set; } = true;
+        public bool UseValueContainerByteBufferDataTransfer { get; set; } = true;
         public bool PreserveStreamsAcrossContexts { get; set; } = true;
         public bool UsePersistentStorage { get; set; } = false;
         public string TopicPrefix { get; set; } = "TestDB";
@@ -139,7 +139,7 @@ namespace MASES.EntityFrameworkCore.KNet.Test.Common
             context.UseCompactedReplicator = UseCompactedReplicator;
             context.UseKNetStreams = UseKNetStreams;
             context.UseEnumeratorWithPrefetch = UseEnumeratorWithPrefetch;
-            context.UseByteBufferDataTransfer = UseByteBufferDataTransfer;
+            context.UseValueContainerByteBufferDataTransfer = UseValueContainerByteBufferDataTransfer;
             context.ManageEvents = ManageEvents;
             context.DefaultSynchronizationTimeout = DefaultSynchronizationTimeout;
 

--- a/test/KEFCore.Benchmark.Test/Benchmark.KNetStreams.Raw.json
+++ b/test/KEFCore.Benchmark.Test/Benchmark.KNetStreams.Raw.json
@@ -1,7 +1,7 @@
 {
   "TopicPrefix": "TestDBBenchmark",
   "BootstrapServers": "192.168.1.114:9092",
-  "UseByteBufferDataTransfer": false,
+  "UseValueContainerByteBufferDataTransfer": false,
   "UseEnumeratorWithPrefetch": false,
   "NumberOfExecutions": 10
 }

--- a/test/KEFCore.Benchmark.Test/Benchmark.KafkaStreams.Raw.json
+++ b/test/KEFCore.Benchmark.Test/Benchmark.KafkaStreams.Raw.json
@@ -1,7 +1,7 @@
 {
   "TopicPrefix": "TestDBBenchmark",
   "UseKNetStreams": false,
-  "UseByteBufferDataTransfer": false,
+  "UseValueContainerByteBufferDataTransfer": false,
   "BootstrapServers": "192.168.0.101:9092",
   "NumberOfExecutions": 10
 }

--- a/test/KEFCore.Complex.Reduced.Test/ReducedComplexTest.KNetStreams.Raw.json
+++ b/test/KEFCore.Complex.Reduced.Test/ReducedComplexTest.KNetStreams.Raw.json
@@ -1,6 +1,6 @@
 {
   "TopicPrefix": "TestDBReducedComplex",
-  "UseByteBufferDataTransfer": false,
+  "UseValueContainerByteBufferDataTransfer": false,
   "UseEnumeratorWithPrefetch": false,
   "BootstrapServers": "192.168.1.114:9092",
   "NumberOfExecutions": 10

--- a/test/KEFCore.Complex.Test/ComplexTest.KNetStreams.Raw.json
+++ b/test/KEFCore.Complex.Test/ComplexTest.KNetStreams.Raw.json
@@ -1,6 +1,6 @@
 {
   "TopicPrefix": "TestDBComplex",
-  "UseByteBufferDataTransfer": false,
+  "UseValueContainerByteBufferDataTransfer": false,
   "UseEnumeratorWithPrefetch": false,
   "BootstrapServers": "192.168.1.114:9092",
   "NumberOfExecutions": 10

--- a/test/KEFCore.MultiLevel.Complex.Test/MultiLevelComplexTest.KNetStreams.Raw.json
+++ b/test/KEFCore.MultiLevel.Complex.Test/MultiLevelComplexTest.KNetStreams.Raw.json
@@ -1,6 +1,6 @@
 {
   "TopicPrefix": "TestDBComplex",
-  "UseByteBufferDataTransfer": false,
+  "UseValueContainerByteBufferDataTransfer": false,
   "UseEnumeratorWithPrefetch": false,
   "BootstrapServers": "192.168.1.114:9092",
   "NumberOfExecutions": 10


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Refactor IKEFCoreSingletonOptions to contain only true singleton options (those that affect the EF Core Service Provider and are shared across all DbContexts pointing to the same physical cluster).

Changes:
- IKEFCoreSingletonOptions now contains only SP-affecting options: serialization types, UseByteBufferDataTransfer, BootstrapServers, UseKNetStreams, UsePersistentStorage, UseCompactedReplicator, topic structure options (UseDeletePolicyForTopic, DefaultNumPartitions, DefaultReplicationFactor, TopicConfig)
- Moved to context-only (KEFCoreOptionsExtension only): TopicPrefix, ApplicationId, ProducerConfig, StreamsConfig, ManageEvents, ReadOnlyMode, DefaultSynchronizationTimeout, UseEnumeratorWithPrefetch, UseStore*, ConsumerConfig, DefaultConsumerInstances
- Deprecated UseGlobalTable: ApplicationId-per-process constraint makes it unnecessary; GlobalKTable also prevents TimestampExtractor usage and post-SaveChanges synchronization
- Updated ExtensionInfo.GetServiceProviderHashCode and ShouldUseSameServiceProvider to use ClusterId + singleton options only
- Updated Initialize to validate singleton options consistency across contexts sharing the same SP

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
