### PR TITLE
Promote ApplicationId, StreamsConfig and ProducerConfig to singleton scope

### DIFF
--- a/src/net/KEFCore/Infrastructure/Internal/IKEFCoreSingletonOptions.cs
+++ b/src/net/KEFCore/Infrastructure/Internal/IKEFCoreSingletonOptions.cs
@@ -19,6 +19,9 @@
 #nullable enable
 
 using MASES.KNet.Common;
+using MASES.KNet.Consumer;
+using MASES.KNet.Producer;
+using MASES.KNet.Streams;
 
 namespace MASES.EntityFrameworkCore.KNet.Infrastructure.Internal;
 /// <summary>
@@ -51,13 +54,22 @@ public interface IKEFCoreSingletonOptions : ISingletonOptions
     string? BootstrapServers { get; }
 
     // ── Backend architecture — in hash ────────────────────────────────────
+    /// <inheritdoc cref="KEFCoreDbContext.UseCompactedReplicator"/>
+    [Obsolete("Option will be removed soon")]
+    bool UseCompactedReplicator { get; }
+    /// <inheritdoc cref="KEFCoreDbContext.ConsumerConfig"/>
+    [Obsolete("Option will be removed soon")]
+    ConsumerConfigBuilder? ConsumerConfig { get; }
     /// <inheritdoc cref="KEFCoreDbContext.UseKNetStreams"/>
     bool UseKNetStreams { get; }
     /// <inheritdoc cref="KEFCoreDbContext.UsePersistentStorage"/>
     bool UsePersistentStorage { get; }
-    /// <inheritdoc cref="KEFCoreDbContext.UseCompactedReplicator"/>
-    [Obsolete("Option will be removed soon")]
-    bool UseCompactedReplicator { get; }
+    /// <inheritdoc cref="KEFCoreDbContext.ApplicationId"/>
+    string? ApplicationId { get; }
+    /// <inheritdoc cref="KEFCoreDbContext.StreamsConfig"/>
+    StreamsConfigBuilder? StreamsConfig { get; }
+    /// <inheritdoc cref="KEFCoreDbContext.ProducerConfig"/>
+    ProducerConfigBuilder? ProducerConfig { get; }
 
     // ── Topic structure — NOT in hash (first-wins at topic creation) ──────
     /// <inheritdoc cref="KEFCoreDbContext.UseDeletePolicyForTopic"/>

--- a/src/net/KEFCore/Infrastructure/Internal/KEFCoreOptionsExtension.cs
+++ b/src/net/KEFCore/Infrastructure/Internal/KEFCoreOptionsExtension.cs
@@ -64,21 +64,21 @@ public class KEFCoreOptionsExtension : IDbContextOptionsExtension, IKEFCoreSingl
         UseKeyByteBufferDataTransfer = copyFrom.UseKeyByteBufferDataTransfer;
         UseValueContainerByteBufferDataTransfer = copyFrom.UseValueContainerByteBufferDataTransfer;
         BootstrapServers = copyFrom.BootstrapServers;
+        // obsolete
+        UseCompactedReplicator = copyFrom.UseCompactedReplicator;
+        ConsumerConfig = ConsumerConfigBuilder.CreateFrom(copyFrom.ConsumerConfig);
         UseKNetStreams = copyFrom.UseKNetStreams;
         UsePersistentStorage = copyFrom.UsePersistentStorage;
-        UseCompactedReplicator = copyFrom.UseCompactedReplicator;
+        ApplicationId = copyFrom.ApplicationId;
+        StreamsConfig = StreamsConfigBuilder.CreateFrom(copyFrom.StreamsConfig);
+        ProducerConfig = ProducerConfigBuilder.CreateFrom(copyFrom.ProducerConfig);
         UseDeletePolicyForTopic = copyFrom.UseDeletePolicyForTopic;
         DefaultNumPartitions = copyFrom.DefaultNumPartitions;
         DefaultReplicationFactor = copyFrom.DefaultReplicationFactor;
         TopicConfig = TopicConfigBuilder.CreateFrom(copyFrom.TopicConfig);
-        // obsolete
-        DefaultConsumerInstances = copyFrom.DefaultConsumerInstances;
-        ConsumerConfig = ConsumerConfigBuilder.CreateFrom(copyFrom.ConsumerConfig);
 
         // ── Context-only options ──────────────────────────────────────────
-        ApplicationId = copyFrom.ApplicationId;
-        ProducerConfig = ProducerConfigBuilder.CreateFrom(copyFrom.ProducerConfig);
-        StreamsConfig = StreamsConfigBuilder.CreateFrom(copyFrom.StreamsConfig);
+        DefaultConsumerInstances = copyFrom.DefaultConsumerInstances;
         ManageEvents = copyFrom.ManageEvents;
         ReadOnlyMode = copyFrom.ReadOnlyMode;
         DefaultSynchronizationTimeout = copyFrom.DefaultSynchronizationTimeout;
@@ -124,13 +124,22 @@ public class KEFCoreOptionsExtension : IDbContextOptionsExtension, IKEFCoreSingl
     public virtual bool UseValueContainerByteBufferDataTransfer { get; set; } = false;
     /// <inheritdoc cref="KEFCoreDbContext.BootstrapServers"/>
     public virtual string? BootstrapServers { get; set; }
+    /// <inheritdoc cref="KEFCoreDbContext.UseCompactedReplicator"/>
+    [Obsolete("Option will be removed soon")]
+    public virtual bool UseCompactedReplicator { get; set; } = false;
+    /// <inheritdoc cref="KEFCoreDbContext.ConsumerConfig"/>
+    [Obsolete("Option will be removed soon")]
+    public virtual ConsumerConfigBuilder? ConsumerConfig { get; set; }
     /// <inheritdoc cref="KEFCoreDbContext.UseKNetStreams"/>
     public virtual bool UseKNetStreams { get; set; } = true;
     /// <inheritdoc cref="KEFCoreDbContext.UsePersistentStorage"/>
     public virtual bool UsePersistentStorage { get; set; } = false;
-    /// <inheritdoc cref="KEFCoreDbContext.UseCompactedReplicator"/>
-    [Obsolete("Option will be removed soon")]
-    public virtual bool UseCompactedReplicator { get; set; } = false;
+    /// <inheritdoc cref="KEFCoreDbContext.ApplicationId"/>
+    public virtual string? ApplicationId { get; set; }
+    /// <inheritdoc cref="KEFCoreDbContext.StreamsConfig"/>
+    public virtual StreamsConfigBuilder? StreamsConfig { get; set; }
+    /// <inheritdoc cref="KEFCoreDbContext.ProducerConfig"/>
+    public virtual ProducerConfigBuilder? ProducerConfig { get; set; }
     /// <inheritdoc cref="KEFCoreDbContext.UseDeletePolicyForTopic"/>
     public virtual bool UseDeletePolicyForTopic { get; set; } = false;
     /// <inheritdoc cref="KEFCoreDbContext.DefaultNumPartitions"/>
@@ -146,15 +155,6 @@ public class KEFCoreOptionsExtension : IDbContextOptionsExtension, IKEFCoreSingl
     /// <inheritdoc cref="KEFCoreDbContext.DefaultConsumerInstances"/>
     [Obsolete("Option will be removed soon")]
     public virtual int? DefaultConsumerInstances { get; set; } = null;
-    /// <inheritdoc cref="KEFCoreDbContext.ConsumerConfig"/>
-    [Obsolete("Option will be removed soon")]
-    public virtual ConsumerConfigBuilder? ConsumerConfig { get; set; }
-    /// <inheritdoc cref="KEFCoreDbContext.ApplicationId"/>
-    public virtual string? ApplicationId { get; set; }
-    /// <inheritdoc cref="KEFCoreDbContext.ProducerConfig"/>
-    public virtual ProducerConfigBuilder? ProducerConfig { get; set; }
-    /// <inheritdoc cref="KEFCoreDbContext.StreamsConfig"/>
-    public virtual StreamsConfigBuilder? StreamsConfig { get; set; }
     /// <inheritdoc cref="KEFCoreDbContext.ManageEvents"/>
     public virtual bool ManageEvents { get; set; } = false;
     /// <inheritdoc cref="KEFCoreDbContext.ReadOnlyMode"/>
@@ -226,6 +226,22 @@ public class KEFCoreOptionsExtension : IDbContextOptionsExtension, IKEFCoreSingl
         clone.BootstrapServers = bootstrapServers;
         return clone;
     }
+    /// <inheritdoc cref="KEFCoreDbContext.UseCompactedReplicator"/>
+    [Obsolete("Option will be removed soon")]
+    public virtual KEFCoreOptionsExtension WithCompactedReplicator(bool useCompactedReplicator = true)
+    {
+        var clone = Clone();
+        clone.UseCompactedReplicator = useCompactedReplicator;
+        return clone;
+    }
+    /// <inheritdoc cref="KEFCoreDbContext.ConsumerConfig"/>
+    [Obsolete("Option will be removed soon")]
+    public virtual KEFCoreOptionsExtension WithConsumerConfig(ConsumerConfigBuilder consumerConfigBuilder)
+    {
+        var clone = Clone();
+        clone.ConsumerConfig = ConsumerConfigBuilder.CreateFrom(consumerConfigBuilder);
+        return clone;
+    }
     /// <inheritdoc cref="KEFCoreDbContext.UseKNetStreams"/>
     public virtual KEFCoreOptionsExtension WithKNetStreams(bool useKNetStreams = true)
     {
@@ -240,12 +256,25 @@ public class KEFCoreOptionsExtension : IDbContextOptionsExtension, IKEFCoreSingl
         clone.UsePersistentStorage = usePersistentStorage;
         return clone;
     }
-    /// <inheritdoc cref="KEFCoreDbContext.UseCompactedReplicator"/>
-    [Obsolete("Option will be removed soon")]
-    public virtual KEFCoreOptionsExtension WithCompactedReplicator(bool useCompactedReplicator = true)
+    /// <inheritdoc cref="KEFCoreDbContext.ApplicationId"/>
+    public virtual KEFCoreOptionsExtension WithApplicationId(string? applicationId)
     {
         var clone = Clone();
-        clone.UseCompactedReplicator = useCompactedReplicator;
+        clone.ApplicationId = applicationId;
+        return clone;
+    }
+    /// <inheritdoc cref="KEFCoreDbContext.StreamsConfig"/>
+    public virtual KEFCoreOptionsExtension WithStreamsConfig(StreamsConfigBuilder streamsConfigBuilder)
+    {
+        var clone = Clone();
+        clone.StreamsConfig = StreamsConfigBuilder.CreateFrom(streamsConfigBuilder);
+        return clone;
+    }
+    /// <inheritdoc cref="KEFCoreDbContext.ProducerConfig"/>
+    public virtual KEFCoreOptionsExtension WithProducerConfig(ProducerConfigBuilder producerConfigBuilder)
+    {
+        var clone = Clone();
+        clone.ProducerConfig = ProducerConfigBuilder.CreateFrom(producerConfigBuilder);
         return clone;
     }
     /// <inheritdoc cref="KEFCoreDbContext.UseDeletePolicyForTopic"/>
@@ -284,36 +313,6 @@ public class KEFCoreOptionsExtension : IDbContextOptionsExtension, IKEFCoreSingl
     {
         var clone = Clone();
         clone.DefaultConsumerInstances = defaultConsumerInstances;
-        return clone;
-    }
-    /// <inheritdoc cref="KEFCoreDbContext.ConsumerConfig"/>
-    [Obsolete("Option will be removed soon")]
-    public virtual KEFCoreOptionsExtension WithConsumerConfig(ConsumerConfigBuilder consumerConfigBuilder)
-    {
-        var clone = Clone();
-        clone.ConsumerConfig = ConsumerConfigBuilder.CreateFrom(consumerConfigBuilder);
-        return clone;
-    }
-
-    /// <inheritdoc cref="KEFCoreDbContext.ApplicationId"/>
-    public virtual KEFCoreOptionsExtension WithApplicationId(string? applicationId)
-    {
-        var clone = Clone();
-        clone.ApplicationId = applicationId;
-        return clone;
-    }
-    /// <inheritdoc cref="KEFCoreDbContext.ProducerConfig"/>
-    public virtual KEFCoreOptionsExtension WithProducerConfig(ProducerConfigBuilder producerConfigBuilder)
-    {
-        var clone = Clone();
-        clone.ProducerConfig = ProducerConfigBuilder.CreateFrom(producerConfigBuilder);
-        return clone;
-    }
-    /// <inheritdoc cref="KEFCoreDbContext.StreamsConfig"/>
-    public virtual KEFCoreOptionsExtension WithStreamsConfig(StreamsConfigBuilder streamsConfigBuilder)
-    {
-        var clone = Clone();
-        clone.StreamsConfig = StreamsConfigBuilder.CreateFrom(streamsConfigBuilder);
         return clone;
     }
     /// <inheritdoc cref="KEFCoreDbContext.ManageEvents"/>
@@ -553,9 +552,10 @@ public class KEFCoreOptionsExtension : IDbContextOptionsExtension, IKEFCoreSingl
             || other.ValueContainerType != ValueContainerType
             || other.UseKeyByteBufferDataTransfer != UseKeyByteBufferDataTransfer
             || other.UseValueContainerByteBufferDataTransfer != UseValueContainerByteBufferDataTransfer
+            || other.UseCompactedReplicator != UseCompactedReplicator
             || other.UseKNetStreams != UseKNetStreams
             || other.UsePersistentStorage != UsePersistentStorage
-            || other.UseCompactedReplicator != UseCompactedReplicator)
+            || other.ApplicationId != ApplicationId)
         {
             throw new InvalidOperationException(
                 "Cannot reuse internal service provider: singleton options mismatch.");
@@ -588,16 +588,19 @@ public class KEFCoreOptionsExtension : IDbContextOptionsExtension, IKEFCoreSingl
                     builder.Append("UseKeyByteBufferDataTransfer=").Append(Extension.UseKeyByteBufferDataTransfer).Append(' ');
                     builder.Append("UseValueContainerByteBufferDataTransfer=").Append(Extension.UseValueContainerByteBufferDataTransfer).Append(' ');
                     builder.Append("BootstrapServers=").Append(Extension.BootstrapServers).Append(' ');
+                    builder.Append("UseCompactedReplicator=").Append(Extension.UseCompactedReplicator).Append(' ');
+                    builder.Append("ConsumerConfig=").Append(Extension.ConsumerConfig?.ToString()).Append(' ');
                     builder.Append("UseKNetStreams=").Append(Extension.UseKNetStreams).Append(' ');
                     builder.Append("UsePersistentStorage=").Append(Extension.UsePersistentStorage).Append(' ');
-                    builder.Append("UseCompactedReplicator=").Append(Extension.UseCompactedReplicator).Append(' ');
+                    builder.Append("ApplicationId=").Append(Extension.ApplicationId).Append(' ');
+                    builder.Append("StreamsConfig=").Append(Extension.StreamsConfig).Append(' ');
+                    builder.Append("ProducerConfig=").Append(Extension.ProducerConfig).Append(' ');
                     builder.Append("UseDeletePolicyForTopic=").Append(Extension.UseDeletePolicyForTopic).Append(' ');
                     builder.Append("DefaultNumPartitions=").Append(Extension.DefaultNumPartitions).Append(' ');
                     builder.Append("DefaultReplicationFactor=").Append(Extension.DefaultReplicationFactor).Append(' ');
+                    builder.Append("TopicConfig=").Append(Extension.TopicConfig).Append(' ');
                     // context
                     builder.Append("DefaultConsumerInstances=").Append(Extension.DefaultConsumerInstances).Append(' ');
-                    builder.Append("ConsumerConfig=").Append(Extension.ConsumerConfig?.ToString()).Append(' ');
-                    builder.Append("ApplicationId=").Append(Extension.ApplicationId).Append(' ');
                     builder.Append("ManageEvents=").Append(Extension.ManageEvents).Append(' ');
                     builder.Append("ReadOnlyMode=").Append(Extension.ReadOnlyMode).Append(' ');
                     builder.Append("DefaultSynchronizationTimeout=").Append(Extension.DefaultSynchronizationTimeout).Append(' ');
@@ -624,9 +627,10 @@ public class KEFCoreOptionsExtension : IDbContextOptionsExtension, IKEFCoreSingl
             hash.Add(Extension.ValueContainerType);
             hash.Add(Extension.UseKeyByteBufferDataTransfer);
             hash.Add(Extension.UseValueContainerByteBufferDataTransfer);
+            hash.Add(Extension.UseCompactedReplicator);
             hash.Add(Extension.UseKNetStreams);
             hash.Add(Extension.UsePersistentStorage);
-            hash.Add(Extension.UseCompactedReplicator);
+            hash.Add(Extension.ApplicationId);
             return hash.ToHashCode();
         }
 
@@ -638,9 +642,10 @@ public class KEFCoreOptionsExtension : IDbContextOptionsExtension, IKEFCoreSingl
             && Extension.ValueContainerType == o.Extension.ValueContainerType
             && Extension.UseKeyByteBufferDataTransfer == o.Extension.UseKeyByteBufferDataTransfer
             && Extension.UseValueContainerByteBufferDataTransfer == o.Extension.UseValueContainerByteBufferDataTransfer
+            && Extension.UseCompactedReplicator == o.Extension.UseCompactedReplicator
             && Extension.UseKNetStreams == o.Extension.UseKNetStreams
             && Extension.UsePersistentStorage == o.Extension.UsePersistentStorage
-            && Extension.UseCompactedReplicator == o.Extension.UseCompactedReplicator;
+            && Extension.ApplicationId == o.Extension.ApplicationId;
 
         public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
         {

--- a/src/net/KEFCore/Infrastructure/Internal/KEFCoreSingletonOptions.cs
+++ b/src/net/KEFCore/Infrastructure/Internal/KEFCoreSingletonOptions.cs
@@ -18,6 +18,12 @@
 
 using MASES.EntityFrameworkCore.KNet.Extensions;
 using MASES.KNet.Common;
+using MASES.KNet.Consumer;
+using MASES.KNet.Producer;
+using MASES.KNet.Streams;
+using Org.Apache.Kafka.Clients.Consumer;
+using Org.Apache.Kafka.Clients.Producer;
+using Org.Apache.Kafka.Streams;
 
 namespace MASES.EntityFrameworkCore.KNet.Infrastructure.Internal;
 /// <summary>
@@ -44,9 +50,13 @@ public class KEFCoreSingletonOptions : IKEFCoreSingletonOptions
         BootstrapServers = kefcoreOptions.BootstrapServers;
         UseKeyByteBufferDataTransfer = kefcoreOptions.UseKeyByteBufferDataTransfer;
         UseValueContainerByteBufferDataTransfer = kefcoreOptions.UseValueContainerByteBufferDataTransfer;
+        UseCompactedReplicator = kefcoreOptions.UseCompactedReplicator;
+        ConsumerConfig = ConsumerConfigBuilder.CreateFrom(kefcoreOptions.ConsumerConfig);
         UseKNetStreams = kefcoreOptions.UseKNetStreams;
         UsePersistentStorage = kefcoreOptions.UsePersistentStorage;
-        UseCompactedReplicator = kefcoreOptions.UseCompactedReplicator;
+        ApplicationId = kefcoreOptions.ApplicationId;
+        StreamsConfig = StreamsConfigBuilder.CreateFrom(kefcoreOptions.StreamsConfig);
+        ProducerConfig = ProducerConfigBuilder.CreateFrom(kefcoreOptions.ProducerConfig);
         // non-hash singleton (first-wins)
         UseDeletePolicyForTopic = kefcoreOptions.UseDeletePolicyForTopic;
         DefaultNumPartitions = kefcoreOptions.DefaultNumPartitions;
@@ -65,9 +75,10 @@ public class KEFCoreSingletonOptions : IKEFCoreSingletonOptions
             || kefcoreOptions.ValueContainerType != ValueContainerType
             || kefcoreOptions.UseKeyByteBufferDataTransfer != UseKeyByteBufferDataTransfer
             || kefcoreOptions.UseValueContainerByteBufferDataTransfer != UseValueContainerByteBufferDataTransfer
+            || kefcoreOptions.UseCompactedReplicator != UseCompactedReplicator
             || kefcoreOptions.UseKNetStreams != UseKNetStreams
             || kefcoreOptions.UsePersistentStorage != UsePersistentStorage
-            || kefcoreOptions.UseCompactedReplicator != UseCompactedReplicator)
+            || kefcoreOptions.ApplicationId != ApplicationId)
         {
             throw new InvalidOperationException(
                 CoreStrings.SingletonOptionChanged(
@@ -82,20 +93,29 @@ public class KEFCoreSingletonOptions : IKEFCoreSingletonOptions
     /// <inheritdoc/>
     public virtual Type? ValueContainerType { get; private set; }
     /// <inheritdoc/>
-    public virtual string? BootstrapServers { get; private set; }
-    /// <inheritdoc/>
-    public virtual bool UseDeletePolicyForTopic { get; private set; }
-    /// <inheritdoc/>
-    [Obsolete("Option will be removed soon")]
-    public virtual bool UseCompactedReplicator { get; private set; }
-    /// <inheritdoc/>
-    public virtual bool UseKNetStreams { get; private set; }
-    /// <inheritdoc/>
-    public virtual bool UsePersistentStorage { get; private set; }
-    /// <inheritdoc/>
     public virtual bool UseKeyByteBufferDataTransfer { get; private set; }
     /// <inheritdoc/>
     public virtual bool UseValueContainerByteBufferDataTransfer { get; private set; }
+    /// <inheritdoc/>
+    public virtual string? BootstrapServers { get; private set; }
+    /// <inheritdoc/>
+    public virtual bool UseDeletePolicyForTopic { get; private set; }
+    /// <inheritdoc cref="KEFCoreDbContext.UseCompactedReplicator"/>
+    [Obsolete("Option will be removed soon")]
+    public virtual bool UseCompactedReplicator { get; private set; }
+    /// <inheritdoc cref="KEFCoreDbContext.ConsumerConfig"/>
+    [Obsolete("Option will be removed soon")]
+    public virtual ConsumerConfigBuilder? ConsumerConfig { get; private set; }
+    /// <inheritdoc cref="KEFCoreDbContext.UseKNetStreams"/>
+    public virtual bool UseKNetStreams { get; private set; }
+    /// <inheritdoc cref="KEFCoreDbContext.UsePersistentStorage"/>
+    public virtual bool UsePersistentStorage { get; private set; }
+    /// <inheritdoc cref="KEFCoreDbContext.ApplicationId"/>
+    public virtual string? ApplicationId { get; private set; }
+    /// <inheritdoc cref="KEFCoreDbContext.StreamsConfig"/>
+    public virtual StreamsConfigBuilder? StreamsConfig { get; private set; }
+    /// <inheritdoc cref="KEFCoreDbContext.ProducerConfig"/>
+    public virtual ProducerConfigBuilder? ProducerConfig { get; private set; }
     /// <inheritdoc/>
     public virtual int DefaultNumPartitions { get; private set; }
     /// <inheritdoc/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

ApplicationId is now singleton and contributes to GetServiceProviderHashCode() and ShouldUseSameServiceProvider() — two contexts with different ApplicationId on the same cluster will use different Service Providers.

StreamsConfig and ProducerConfig are singleton (first-wins, not in hash) since they contain cluster-level configuration not dependent on the model.

Replaced by-reference assignment of ConsumerConfig, StreamsConfig and ProducerConfig in KEFCoreSingletonOptions.Initialize() with CreateFrom() copies to prevent shared mutable state between singleton and originating context.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
