### PR TITLE
Add in-memory value buffer caching for entity types

### DIFF
--- a/src/documentation/articles/conventions.md
+++ b/src/documentation/articles/conventions.md
@@ -452,3 +452,76 @@ protected override void OnModelCreating(ModelBuilder modelBuilder)
 ```
 
 See [performance tips](performancetips.md#rocksdb-configuration) for full details on the lifecycle model and object retention rules.
+
+## Value buffer cache convention
+
+`KEFCoreValueBufferCacheConvention` resolves per-entity in-memory result cache configuration at model finalization time. When active, the first **complete** enumeration of `GetValueBuffers()` or `GetValueBuffersReverse()` populates an internal list with the deserialized `ValueBuffer` objects. Subsequent full scans within the TTL window are served from that list — zero JNI cost, zero deserialization overhead.
+
+The cache is stored in `EntityTypeProducer` (singleton per cluster and `ApplicationId`) and is therefore shared across all `DbContext` instances using the same cluster.
+
+### When the cache is populated vs bypassed
+
+| Access path | Cache behavior |
+|---|---|
+| `GetValueBuffers()` — full scan | Populates cache on first complete enumeration; hits cache on subsequent full scans within TTL |
+| `GetValueBuffersReverse()` — full reverse scan | Independent cache with its own TTL; same population/hit rules |
+| Single key lookup (`UseStoreSingleKeyLookup`) | Always bypasses cache — goes directly to state store |
+| Key range scan (`UseStoreKeyRange`, `UseStoreReverseKeyRange`) | Always bypasses cache — result depends on range parameters |
+| Prefix scan (`UseStorePrefixScan`) | Always bypasses cache |
+
+**Partial enumeration** (e.g. `First()`, `Take(3)`, any LINQ operator that stops early) **never populates the cache**. If the enumerator is disposed before `MoveNext()` returns `false`, the accumulated list is discarded — the next call will re-fetch from the state store. This is intentional: a partial list would produce incorrect results for subsequent full-scan queries.
+
+### Invalidation
+
+The cache is invalidated automatically when new data arrives from the Kafka cluster via `FreshEventChange` — i.e. after any `SaveChanges` that writes to that entity's topic reaches the Streams state store. `EnsureSynchronized` can be used to wait for the state store to be in sync before querying; the cache is invalidated before the wait completes.
+
+Both forward and reverse caches are invalidated together on any write.
+
+### Resolution priority
+
+1. `KEFCoreValueBufferCacheAttribute` applied to the entity class
+2. `HasKEFCoreValueBufferCache()` applied via fluent API
+
+### Usage examples
+
+```csharp
+// Attribute — cache forward and reverse scans for 30 seconds
+[KEFCoreValueBufferCacheAttribute(ttlSeconds: 30)]
+[Table("Country")]
+public class Country { ... }
+
+// Attribute — different TTL for forward and reverse
+[KEFCoreValueBufferCacheAttribute(ttlSeconds: 60, reverseTtlSeconds: 30)]
+[Table("Product")]
+public class Product { ... }
+
+// Attribute — cache only forward scan, disable reverse cache
+[KEFCoreValueBufferCacheAttribute(ttlSeconds: 60, reverseTtlSeconds: 0)]
+[Table("PriceList")]
+public class PriceList { ... }
+
+// Fluent API — same TTL for both directions
+protected override void OnModelCreating(ModelBuilder modelBuilder)
+{
+    modelBuilder.Entity<Country>()
+                .HasKEFCoreValueBufferCache(ttl: TimeSpan.FromSeconds(30));
+}
+
+// Fluent API — different TTL for forward and reverse
+protected override void OnModelCreating(ModelBuilder modelBuilder)
+{
+    modelBuilder.Entity<Product>()
+                .HasKEFCoreValueBufferCache(
+                    ttl: TimeSpan.FromSeconds(60),
+                    reverseTtl: TimeSpan.FromSeconds(30));
+}
+```
+
+> [!TIP]
+> This cache is most effective for entities that are queried frequently with full scans but written infrequently — reference data, lookup tables, configuration entities. For entities with high write frequency the cache will be invalidated often and the benefit diminishes.
+
+> [!NOTE]
+> A `TTL` of zero or negative disables caching for that direction — the proxy still exists but acts as a transparent pass-through with no allocation overhead. When neither attribute nor fluent API is applied, TTL defaults to zero and the proxy is always a pass-through.
+
+> [!IMPORTANT]
+> The cache operates at the `EntityTypeProducer` level — it is shared across all `DbContext` instances on the same cluster and `ApplicationId`. This means a write from one context will invalidate the cache for all contexts sharing the same producer. This is the correct behavior for consistency.

--- a/src/documentation/articles/conventions.md
+++ b/src/documentation/articles/conventions.md
@@ -455,27 +455,33 @@ See [performance tips](performancetips.md#rocksdb-configuration) for full detail
 
 ## Value buffer cache convention
 
-`KEFCoreValueBufferCacheConvention` resolves per-entity in-memory result cache configuration at model finalization time. When active, the first **complete** enumeration of `GetValueBuffers()` or `GetValueBuffersReverse()` populates an internal list with the deserialized `ValueBuffer` objects. Subsequent full scans within the TTL window are served from that list — zero JNI cost, zero deserialization overhead.
+`KEFCoreValueBufferCacheConvention` resolves per-entity in-memory result cache configuration at model finalization time. Two independent caches are maintained per entity type — one for forward enumeration and one for reverse — each backed by a `SortedList<TKey, ValueBuffer>` keyed on the entity primary key with an `IComparer<TKey>` derived from `IKey` at construction time.
 
-The cache is stored in `EntityTypeProducer` (singleton per cluster and `ApplicationId`) and is therefore shared across all `DbContext` instances using the same cluster.
+Both caches live in `EntityTypeProducer` (singleton per cluster and `ApplicationId`) and are shared across all `DbContext` instances on the same cluster.
 
-### When the cache is populated vs bypassed
+### Forward cache
 
-| Access path | Cache behavior |
-|---|---|
-| `GetValueBuffers()` — full scan | Populates cache on first complete enumeration; hits cache on subsequent full scans within TTL |
-| `GetValueBuffersReverse()` — full reverse scan | Independent cache with its own TTL; same population/hit rules |
-| Single key lookup (`UseStoreSingleKeyLookup`) | Always bypasses cache — goes directly to state store |
-| Key range scan (`UseStoreKeyRange`, `UseStoreReverseKeyRange`) | Always bypasses cache — result depends on range parameters |
-| Prefix scan (`UseStorePrefixScan`) | Always bypasses cache |
+Populated by the first **complete** enumeration of `GetValueBuffers()`. Once warm, it also serves:
 
-**Partial enumeration** (e.g. `First()`, `Take(3)`, any LINQ operator that stops early) **never populates the cache**. If the enumerator is disposed before `MoveNext()` returns `false`, the accumulated list is discarded — the next call will re-fetch from the state store. This is intentional: a partial list would produce incorrect results for subsequent full-scan queries.
+- **Single key lookup** — binary search on `SortedList.Keys`, `O(log n)`, zero JNI
+- **Key range** — index scan between lower/upper bound, zero JNI
+- **Prefix scan** — scan from first matching key, zero JNI
+
+### Reverse cache
+
+Populated by the first **complete** enumeration of `GetValueBuffersReverse()`. Once warm, it also serves:
+
+- **Reverse range** — index scan in reverse order, zero JNI
+
+When cold, `GetValueBuffersReverse()` falls back to the native RocksDB reverse iterator — more efficient than any .NET alternative.
+
+### Partial enumeration
+
+Partial enumerations (e.g. `First()`, `Take(n)`) never populate either cache. If the enumerator is disposed before `MoveNext()` returns `false`, any accumulated data is discarded — the next call re-fetches from the state store.
 
 ### Invalidation
 
-The cache is invalidated automatically when new data arrives from the Kafka cluster via `FreshEventChange` — i.e. after any `SaveChanges` that writes to that entity's topic reaches the Streams state store. `EnsureSynchronized` can be used to wait for the state store to be in sync before querying; the cache is invalidated before the wait completes.
-
-Both forward and reverse caches are invalidated together on any write.
+Both caches are invalidated together when new data arrives from the cluster via `FreshEventChange` — which fires after any `SaveChanges` that writes to that entity's topic reaches the Streams state store.
 
 ### Resolution priority
 
@@ -485,43 +491,60 @@ Both forward and reverse caches are invalidated together on any write.
 ### Usage examples
 
 ```csharp
-// Attribute — cache forward and reverse scans for 30 seconds
+// Attribute — same TTL for both forward and reverse (default: reverseTtlSeconds = ttlSeconds)
 [KEFCoreValueBufferCacheAttribute(ttlSeconds: 30)]
 [Table("Country")]
 public class Country { ... }
 
-// Attribute — different TTL for forward and reverse
-[KEFCoreValueBufferCacheAttribute(ttlSeconds: 60, reverseTtlSeconds: 30)]
+// Attribute — different TTLs: longer forward, shorter reverse
+[KEFCoreValueBufferCacheAttribute(ttlSeconds: 60, reverseTtlSeconds: 15)]
 [Table("Product")]
 public class Product { ... }
 
-// Attribute — cache only forward scan, disable reverse cache
+// Attribute — only forward cache, reverse disabled
 [KEFCoreValueBufferCacheAttribute(ttlSeconds: 60, reverseTtlSeconds: 0)]
 [Table("PriceList")]
 public class PriceList { ... }
 
-// Fluent API — same TTL for both directions
+// Attribute — only reverse cache (entity always queried OrderByDescending)
+[KEFCoreValueBufferCacheAttribute(ttlSeconds: 0, reverseTtlSeconds: 30)]
+[Table("EventLog")]
+public class EventLog { ... }
+
+// Fluent API — same TTL for both (reverseTtl defaults to ttl when null)
 protected override void OnModelCreating(ModelBuilder modelBuilder)
 {
     modelBuilder.Entity<Country>()
                 .HasKEFCoreValueBufferCache(ttl: TimeSpan.FromSeconds(30));
 }
 
-// Fluent API — different TTL for forward and reverse
+// Fluent API — different TTLs
 protected override void OnModelCreating(ModelBuilder modelBuilder)
 {
     modelBuilder.Entity<Product>()
                 .HasKEFCoreValueBufferCache(
                     ttl: TimeSpan.FromSeconds(60),
+                    reverseTtl: TimeSpan.FromSeconds(15));
+}
+
+// Fluent API — only reverse cache
+protected override void OnModelCreating(ModelBuilder modelBuilder)
+{
+    modelBuilder.Entity<EventLog>()
+                .HasKEFCoreValueBufferCache(
+                    ttl: TimeSpan.Zero,
                     reverseTtl: TimeSpan.FromSeconds(30));
 }
 ```
 
 > [!TIP]
-> This cache is most effective for entities that are queried frequently with full scans but written infrequently — reference data, lookup tables, configuration entities. For entities with high write frequency the cache will be invalidated often and the benefit diminishes.
+> This cache is most effective for reference data and lookup tables — entities queried frequently with full scans but written rarely. For entities with high write frequency the cache is invalidated often and the benefit diminishes.
 
 > [!NOTE]
-> A `TTL` of zero or negative disables caching for that direction — the proxy still exists but acts as a transparent pass-through with no allocation overhead. When neither attribute nor fluent API is applied, TTL defaults to zero and the proxy is always a pass-through.
+> A TTL of zero or negative disables that cache direction. The internal proxy is always created but acts as a transparent pass-through with no allocation overhead when TTL is zero.
+
+> [!NOTE]
+> Enabling both caches doubles memory consumption for that entity. The `SortedList` for each direction holds an independent copy of all `ValueBuffer` objects (each with its own `object[]`). Size the TTL accordingly.
 
 > [!IMPORTANT]
-> The cache operates at the `EntityTypeProducer` level — it is shared across all `DbContext` instances on the same cluster and `ApplicationId`. This means a write from one context will invalidate the cache for all contexts sharing the same producer. This is the correct behavior for consistency.
+> Both caches operate at the `EntityTypeProducer` level — shared across all `DbContext` instances on the same cluster and `ApplicationId`. A write from any context invalidates both caches for all contexts sharing the same producer.

--- a/src/documentation/articles/currentstate.md
+++ b/src/documentation/articles/currentstate.md
@@ -18,3 +18,12 @@ The latest release implements these features:
 * [x] ComplexType equality enforcement via `KEFCoreComplexTypeEquatableConvention` with opt-out via `KEFCoreIgnoreEquatableCheckAttribute`
 * [x] ComplexType converter registration via `KEFCoreComplexTypeConverterConvention` — supports `KEFCoreComplexTypeConverterAttribute` and fluent API (`HasKEFCoreComplexTypeConverter`)
 * [x] `StreamsManager` lifecycle managed per `ApplicationId` via `IKEFCoreCluster.GetOrCreateStreamsManager`
+* [x] Per-entity topic partitions, replication factor, and retention — `KEFCoreTopicPartitionsConvention`, `KEFCoreTopicRetentionConvention`
+* [x] Per-entity read-only mode — `KEFCoreReadOnlyConvention`, `KEFCoreReadOnlyAttribute`
+* [x] Per-entity store lookup optimization flags — `KEFCoreStoreLookupConvention`, `KEFCoreStoreLookupAttribute`
+* [x] Per-entity serialization override — `KEFCoreSerDesConvention`, `KEFCoreSerDesAttribute`
+* [x] Per-entity producer configuration — `KEFCoreProducerConvention`, `KEFCoreProducerAttribute`
+* [x] Kafka transactional producer support — `KEFCoreTransactionalConvention`, `ITransactionalEntityTypeProducer`, `KEFCoreTransactionManager`
+* [x] Per-entity RocksDB lifecycle handler — `KEFCoreRocksDbLifecycleAttributeConvention`, `KEFCoreRocksDbLifecycleAttribute` (requires KNet with `IRocksDbLifecycleHandler`)
+* [x] SSL/SASL broker authentication — `SslConfig`, `SaslConfig`, `SecurityProtocol` singleton options applied to all internal Kafka clients
+* [x] Value buffer result cache — `KEFCoreValueBufferCacheConvention`, `KEFCoreValueBufferCacheAttribute`, TTL-based `CachedValueBufferEnumerable` with automatic invalidation on writes

--- a/src/documentation/articles/options.md
+++ b/src/documentation/articles/options.md
@@ -46,13 +46,13 @@ These are cluster-level but do not affect the Service Provider cache key. The va
 | `TopicConfig` | `null` | Cluster-level topic configuration — retention can be overridden per entity via `KEFCoreTopicRetentionAttribute` or `HasKEFCoreTopicRetention()` |
 | `StreamsConfig` | `null` | Kafka Streams application configuration |
 | `ProducerConfig` | `null` | Cluster-level producer configuration (first-wins) — individual settings can be overridden per entity via `KEFCoreProducerAttribute` or `HasKEFCoreProducer()` |
-| `SecurityProtocol` | `null` | Security protocol for broker connections — set to `SSL`, `SASL_PLAINTEXT`, or `SASL_SSL` to enable encrypted or authenticated connections; must be consistent with `SslConfigs` and `SaslConfigs` |
-| `SslConfigs` | `null` | SSL/TLS configuration for encrypted broker connections — built via `SslConfigsBuilder`; required when `SecurityProtocol` is `SSL` or `SASL_SSL` |
-| `SaslConfigs` | `null` | SASL authentication configuration — built via `SaslConfigsBuilder`; required when `SecurityProtocol` is `SASL_PLAINTEXT` or `SASL_SSL` |
+| `SecurityProtocol` | `null` | Security protocol for broker connections — set to `SSL`, `SASL_PLAINTEXT`, or `SASL_SSL` to enable encrypted or authenticated connections; must be consistent with `SslConfig` and `SaslConfig` |
+| `SslConfig` | `null` | SSL/TLS configuration built via `SslConfigsBuilder` — required when `SecurityProtocol` is `SSL` or `SASL_SSL`; applied automatically to all internal Kafka clients via `WithSslConfigs()` |
+| `SaslConfig` | `null` | SASL authentication configuration built via `SaslConfigsBuilder` — required when `SecurityProtocol` is `SASL_PLAINTEXT` or `SASL_SSL`; applied automatically to all internal Kafka clients via `WithSaslConfigs()` |
 
 ## Secure broker connections
 
-`SecurityProtocol`, `SslConfigs`, and `SaslConfigs` are cluster-level options used to authenticate and encrypt the connection between KEFCore and the broker. They are applied to all internal Kafka clients (producer, admin client, and Streams topology).
+`SecurityProtocol`, `SslConfig`, and `SaslConfig` are cluster-level first-wins options that configure authentication and encryption for all internal Kafka clients. When set, `SslConfig` and `SaslConfig` are merged automatically into `ProducerOptionsBuilder()` and `StreamsOptions()` via `WithSslConfigs()` and `WithSaslConfigs()` — no additional per-client configuration is needed.
 
 The example below shows `SASL_SSL` — TLS encryption combined with SASL/PLAIN authentication, the most common configuration for managed cloud brokers (Amazon MSK, Confluent Cloud, Aiven, etc.):
 
@@ -61,12 +61,12 @@ optionsBuilder.UseKEFCore(opt => opt
     .WithBootstrapServers("KAFKA-SERVER:9093")
     .WithApplicationId("MyApp")
     .WithSecurityProtocol(SecurityProtocol.SASL_SSL)
-    .WithSslConfig(new SslConfigsBuilder()
+    .WithSslConfig(SslConfigsBuilder.Create()
         .WithSslTruststoreLocation("/path/to/truststore.jks")
         .WithSslTruststorePassword(new Password("truststore-password"))
         .WithSslKeystoreLocation("/path/to/keystore.jks")
-        .WithSslKeystoreLocation(new Password("keystore-password")))
-    .WithSaslConfig(new SaslConfigsBuilder()
+        .WithSslKeystorePassword(new Password("keystore-password")))
+    .WithSaslConfig(SaslConfigsBuilder.Create()
         .WithSaslMechanism("PLAIN")
         .WithSaslJaasConfig(new Password(
             "org.apache.kafka.common.security.plain.PlainLoginModule required " +
@@ -74,20 +74,42 @@ optionsBuilder.UseKEFCore(opt => opt
 );
 ```
 
-For brokers that only require TLS (no SASL), use `SecurityProtocol.SSL` and omit `WithSaslConfig`. For SCRAM-based authentication, replace `"PLAIN"` with `"SCRAM-SHA-256"` or `"SCRAM-SHA-512"` and the corresponding JAAS login module (`ScramLoginModule`). The default SASL mechanism when `SaslConfigs` is set without an explicit mechanism is `GSSAPI` (Kerberos).
+Or via `KEFCoreDbContext` properties:
+
+```csharp
+using var context = new BloggingContext()
+{
+    BootstrapServers = "KAFKA-SERVER:9093",
+    ApplicationId = "MyApp",
+    SecurityProtocol = SecurityProtocol.SASL_SSL,
+    SslConfig = SslConfigsBuilder.Create()
+        .WithSslTruststoreLocation("/path/to/truststore.jks")
+        .WithSslTruststorePassword(new Password("truststore-password")),
+    SaslConfig = SaslConfigsBuilder.Create()
+        .WithSaslMechanism("PLAIN")
+        .WithSaslJaasConfig(new Password(
+            "org.apache.kafka.common.security.plain.PlainLoginModule required " +
+            "username=\"myuser\" password=\"mypassword\";")),
+};
+```
+
+For brokers that only require TLS (no SASL), use `SecurityProtocol.SSL` and omit `WithSaslConfig`. For SCRAM-based authentication, replace `"PLAIN"` with `"SCRAM-SHA-256"` or `"SCRAM-SHA-512"` and the corresponding JAAS login module (`ScramLoginModule`). The default SASL mechanism when `SaslConfig` is set without an explicit mechanism is `GSSAPI` (Kerberos).
 
 | `SecurityProtocol` value | When to use |
 |---|---|
 | `PLAINTEXT` (default) | Unencrypted, unauthenticated — development and trusted networks only |
-| `SSL` | TLS encryption, no SASL authentication — requires `SslConfigs` |
-| `SASL_PLAINTEXT` | SASL authentication, no TLS encryption — requires `SaslConfigs` |
-| `SASL_SSL` | TLS encryption + SASL authentication — requires both `SslConfigs` and `SaslConfigs` |
+| `SSL` | TLS encryption, no SASL — requires `SslConfig`; omit `SaslConfig` |
+| `SASL_PLAINTEXT` | SASL authentication, no TLS — requires `SaslConfig`; omit `SslConfig` |
+| `SASL_SSL` | TLS + SASL — requires both `SslConfig` and `SaslConfig` |
 
 > [!IMPORTANT]
 > These options are **first-wins singleton** — the values set by the first `DbContext` to initialize the cluster are used for all subsequent contexts on the same cluster. Ensure all `DbContext` instances that share the same cluster use the same security configuration.
 
 > [!NOTE]
-> The `SslConfigsBuilder` and `SaslConfigsBuilder` builders expose only the properties relevant to their scope. Refer to the [Apache Kafka™ security documentation](https://kafka.apache.org/documentation/#security) and the KNet API documentation for the full list of available properties.
+> `SslConfig` and `SaslConfig` do **not** participate in the Service Provider cache key hash — they are connection-level parameters, not service registration parameters. Two contexts with the same cluster identity and different SSL configurations will see the first-wins values applied without creating a separate Service Provider.
+
+> [!NOTE]
+> `SslConfigsBuilder` and `SaslConfigsBuilder` expose typed properties for every Kafka SSL and SASL configuration key. Refer to the [Apache Kafka™ security documentation](https://kafka.apache.org/documentation/#security) and the KNet API documentation for the full list of available properties.
 
 ## Context-scoped options
 

--- a/src/documentation/articles/performancetips.md
+++ b/src/documentation/articles/performancetips.md
@@ -192,6 +192,61 @@ The `data` dictionary passed to `onSetConfig` is the per-store lifetime containe
 
 ---
 
+## Value buffer cache
+
+For entities queried with full scans but written infrequently, KEFCore supports an in-memory result cache that eliminates the deserialization and JNI boundary cost on repeated full-scan queries. The cache is per entity type, stored in `EntityTypeProducer` (singleton per cluster and `ApplicationId`), and shared across all `DbContext` instances on the same cluster.
+
+### How it works
+
+The cache is implemented as a `CachedValueBufferEnumerable` proxy over `GetValueBuffers()` and `GetValueBuffersReverse()`. On the first **complete** enumeration, the proxy accumulates all `ValueBuffer` objects into an internal list. Subsequent full scans within the TTL window return that list directly — zero JNI calls, zero deserialization.
+
+If the caller stops early (e.g. `First()`, `Take(3)`, any LINQ operator that disposes the enumerator before it is exhausted), the accumulated list is discarded and the next call re-fetches from the state store. This is intentional: a partial list would return incorrect results for subsequent full scans.
+
+The cache is invalidated automatically when new data arrives from the cluster via `FreshEventChange` — which fires after any `SaveChanges` that writes to that entity's topic reaches the Streams state store. Both forward and reverse caches are invalidated together.
+
+### What bypasses the cache
+
+Single key lookups, key range scans, reverse range scans, and prefix scans always go directly to the state store regardless of TTL. Only `GetValueBuffers()` (full forward scan) and `GetValueBuffersReverse()` (full reverse scan) participate in the cache.
+
+### Configuration
+
+Enable the cache via `KEFCoreValueBufferCacheAttribute` or `HasKEFCoreValueBufferCache()`. The TTL is specified in seconds for the attribute and as `TimeSpan` for the fluent API. Forward and reverse scans have independent TTLs.
+
+```csharp
+// Attribute — same TTL for forward and reverse
+[KEFCoreValueBufferCacheAttribute(ttlSeconds: 30)]
+[Table("Country")]
+public class Country { ... }
+
+// Attribute — longer TTL for forward scan, shorter for reverse
+[KEFCoreValueBufferCacheAttribute(ttlSeconds: 60, reverseTtlSeconds: 15)]
+[Table("Product")]
+public class Product { ... }
+
+// Fluent API
+protected override void OnModelCreating(ModelBuilder modelBuilder)
+{
+    modelBuilder.Entity<Country>()
+                .HasKEFCoreValueBufferCache(ttl: TimeSpan.FromSeconds(30));
+
+    modelBuilder.Entity<Product>()
+                .HasKEFCoreValueBufferCache(
+                    ttl: TimeSpan.FromSeconds(60),
+                    reverseTtl: TimeSpan.FromSeconds(15));
+}
+```
+
+> [!TIP]
+> This cache delivers the greatest benefit for reference data and lookup tables — entities that are read frequently with full scans (`ToList()`, `Count()`, `OrderBy()`) but written rarely. For entities with frequent writes the cache will be invalidated often and the benefit diminishes.
+
+> [!NOTE]
+> Setting `ttlSeconds: 0` or a negative value disables caching for that direction. The proxy is always created but acts as a transparent pass-through with no allocation overhead when TTL is zero.
+
+> [!IMPORTANT]
+> The cache lives in `EntityTypeProducer` — it is shared across all `DbContext` instances using the same cluster and `ApplicationId`. A write from any context invalidates the cache for all contexts sharing the same producer. This is the correct behavior for consistency.
+
+---
+
 ## Enumerator prefetch
 
 `UseEnumeratorWithPrefetch` (context-scoped, default: `true`) activates enumerator instances that prefetch data from the state store in batches, reducing JVM boundary crossings during enumeration.

--- a/src/documentation/articles/performancetips.md
+++ b/src/documentation/articles/performancetips.md
@@ -194,56 +194,75 @@ The `data` dictionary passed to `onSetConfig` is the per-store lifetime containe
 
 ## Value buffer cache
 
-For entities queried with full scans but written infrequently, KEFCore supports an in-memory result cache that eliminates the deserialization and JNI boundary cost on repeated full-scan queries. The cache is per entity type, stored in `EntityTypeProducer` (singleton per cluster and `ApplicationId`), and shared across all `DbContext` instances on the same cluster.
+For entities queried with full scans but written infrequently, KEFCore supports an in-memory result cache that eliminates deserialization and JNI boundary cost on repeated queries. Two independent caches are maintained per entity type — one for forward enumeration and one for reverse — each a `SortedList<TKey, ValueBuffer>` keyed on the entity primary key.
 
 ### How it works
 
-The cache is implemented as a `CachedValueBufferEnumerable` proxy over `GetValueBuffers()` and `GetValueBuffersReverse()`. On the first **complete** enumeration, the proxy accumulates all `ValueBuffer` objects into an internal list. Subsequent full scans within the TTL window return that list directly — zero JNI calls, zero deserialization.
+Each cache is populated lazily on the first **complete** enumeration in its direction. The `PopulatingEnumerator` accumulates `(key, ValueBuffer)` pairs as the caller iterates. On `Dispose`, if the enumeration was complete (`MoveNext` returned `false`), the `SortedList` is committed to the cache with the configured expiry. If the caller stopped early, the accumulated data is discarded — no partial population.
 
-If the caller stops early (e.g. `First()`, `Take(3)`, any LINQ operator that disposes the enumerator before it is exhausted), the accumulated list is discarded and the next call re-fetches from the state store. This is intentional: a partial list would return incorrect results for subsequent full scans.
+Once warm, the `SortedList` serves all access paths in that direction:
 
-The cache is invalidated automatically when new data arrives from the cluster via `FreshEventChange` — which fires after any `SaveChanges` that writes to that entity's topic reaches the Streams state store. Both forward and reverse caches are invalidated together.
+| Access path | Forward cache | Reverse cache |
+|---|---|---|
+| `GetValueBuffers()` — full scan | Populates on first complete enumeration; hits on subsequent | — |
+| `GetValueBuffersReverse()` — full reverse scan | — | Populates on first complete enumeration; hits on subsequent; cold → native RocksDB reverse iterator |
+| Single key lookup | `O(log n)` binary search on `Keys` array, zero JNI | — |
+| Key range | Index scan lower→upper bound, zero JNI | — |
+| Reverse range | — | Index scan upper→lower bound, zero JNI |
+| Prefix scan | Scan from first matching key, zero JNI | — |
 
-### What bypasses the cache
+The `SortedList` is backed by two parallel arrays (`keys[]` and `values[]`). Reverse iteration is direct index traversal — `O(n)`, zero allocation, no buffering.
 
-Single key lookups, key range scans, reverse range scans, and prefix scans always go directly to the state store regardless of TTL. Only `GetValueBuffers()` (full forward scan) and `GetValueBuffersReverse()` (full reverse scan) participate in the cache.
+### Invalidation
+
+Both caches are invalidated together when new data from the cluster arrives via `FreshEventChange`, which fires after any `SaveChanges` reaches the Streams state store. `IsWarm` is checked as a guard before constructing key objects — key construction has a non-trivial allocation cost and is skipped when the cache is definitely cold.
+
+### Memory considerations
+
+Enabling both forward and reverse caches doubles memory consumption for that entity — each holds an independent copy of all `ValueBuffer` objects. For large entities, enable only the direction that is actually queried frequently.
 
 ### Configuration
 
-Enable the cache via `KEFCoreValueBufferCacheAttribute` or `HasKEFCoreValueBufferCache()`. The TTL is specified in seconds for the attribute and as `TimeSpan` for the fluent API. Forward and reverse scans have independent TTLs.
-
 ```csharp
-// Attribute — same TTL for forward and reverse
+// Attribute — same TTL for forward and reverse (default: reverseTtlSeconds = ttlSeconds)
 [KEFCoreValueBufferCacheAttribute(ttlSeconds: 30)]
 [Table("Country")]
 public class Country { ... }
 
-// Attribute — longer TTL for forward scan, shorter for reverse
+// Attribute — different TTLs
 [KEFCoreValueBufferCacheAttribute(ttlSeconds: 60, reverseTtlSeconds: 15)]
 [Table("Product")]
 public class Product { ... }
 
-// Fluent API
-protected override void OnModelCreating(ModelBuilder modelBuilder)
-{
-    modelBuilder.Entity<Country>()
-                .HasKEFCoreValueBufferCache(ttl: TimeSpan.FromSeconds(30));
+// Attribute — only forward cache
+[KEFCoreValueBufferCacheAttribute(ttlSeconds: 60, reverseTtlSeconds: 0)]
+[Table("PriceList")]
+public class PriceList { ... }
 
-    modelBuilder.Entity<Product>()
-                .HasKEFCoreValueBufferCache(
-                    ttl: TimeSpan.FromSeconds(60),
-                    reverseTtl: TimeSpan.FromSeconds(15));
-}
+// Attribute — only reverse cache (entity always queried OrderByDescending)
+[KEFCoreValueBufferCacheAttribute(ttlSeconds: 0, reverseTtlSeconds: 30)]
+[Table("EventLog")]
+public class EventLog { ... }
+
+// Fluent API — same TTL for both (reverseTtl defaults to ttl)
+modelBuilder.Entity<Country>()
+            .HasKEFCoreValueBufferCache(ttl: TimeSpan.FromSeconds(30));
+
+// Fluent API — different TTLs
+modelBuilder.Entity<Product>()
+            .HasKEFCoreValueBufferCache(
+                ttl: TimeSpan.FromSeconds(60),
+                reverseTtl: TimeSpan.FromSeconds(15));
 ```
 
 > [!TIP]
-> This cache delivers the greatest benefit for reference data and lookup tables — entities that are read frequently with full scans (`ToList()`, `Count()`, `OrderBy()`) but written rarely. For entities with frequent writes the cache will be invalidated often and the benefit diminishes.
+> This cache is most effective for reference data and lookup tables — entities queried frequently but written rarely. For entities with high write frequency the cache is invalidated often and the benefit diminishes.
 
 > [!NOTE]
-> Setting `ttlSeconds: 0` or a negative value disables caching for that direction. The proxy is always created but acts as a transparent pass-through with no allocation overhead when TTL is zero.
+> A TTL of zero or negative disables that cache direction. The internal `CachedValueBufferStore<TKey>` proxy is always created but acts as a transparent pass-through with no allocation overhead.
 
 > [!IMPORTANT]
-> The cache lives in `EntityTypeProducer` — it is shared across all `DbContext` instances using the same cluster and `ApplicationId`. A write from any context invalidates the cache for all contexts sharing the same producer. This is the correct behavior for consistency.
+> Both caches are shared across all `DbContext` instances on the same cluster and `ApplicationId`. A write from any context invalidates both caches for all contexts sharing the same producer.
 
 ---
 

--- a/src/documentation/articles/roadmap.md
+++ b/src/documentation/articles/roadmap.md
@@ -21,6 +21,16 @@ The roadmap can be synthetized in the following points:
 * [x] `StreamsManager` factory — lifecycle managed per `ApplicationId` via `IKEFCoreCluster` (#501)
 * [x] ComplexType LINQ binding — `TryBindMember` extension, `KEFCoreComplexTypeProjectionExpression` (#491)
 * [x] `TranslateRightJoin` implementation — EF Core 10 requirement (#514)
+* [x] Per-entity topic partitions and replication factor — `KEFCoreTopicPartitionsConvention`, `KEFCoreTopicReplicationFactorConvention` (#417)
+* [x] Per-entity topic retention — `KEFCoreTopicRetentionConvention`, `KEFCoreTopicRetentionAttribute` (#417)
+* [x] Per-entity read-only mode — `KEFCoreReadOnlyConvention`, `KEFCoreReadOnlyAttribute` (#417)
+* [x] Per-entity store lookup optimization flags — `KEFCoreStoreLookupConvention`, `KEFCoreStoreLookupAttribute` (#417)
+* [x] Per-entity serialization override — `KEFCoreSerDesConvention`, `KEFCoreSerDesAttribute` (#417)
+* [x] Per-entity producer configuration — `KEFCoreProducerConvention`, `KEFCoreProducerAttribute` (#417)
+* [x] Kafka transactional producer support — `KEFCoreTransactionalConvention`, `KEFCoreTransactionalAttribute`, `ITransactionalEntityTypeProducer` (#544, #545)
+* [x] Per-entity RocksDB lifecycle handler — `KEFCoreRocksDbLifecycleAttributeConvention`, `KEFCoreRocksDbLifecycleAttribute` (#551, #552)
+* [x] SSL/SASL broker authentication — `SslConfig`, `SaslConfig`, `SecurityProtocol` singleton options; `SslConfigsBuilder`, `SaslConfigsBuilder` from KNet (#1465)
+* [x] Value buffer result cache — `KEFCoreValueBufferCacheConvention`, `KEFCoreValueBufferCacheAttribute`, `CachedValueBufferEnumerable` proxy with TTL and auto-invalidation on `FreshEventChange`
 * [ ] Remove deprecated options: `UseCompactedReplicator`, `UseGlobalTable`, `ManageEvents`, `ConsumerConfig`, `DefaultConsumerInstances`
 * [ ] Full documentation update for new conventions and options architecture
 

--- a/src/net/KEFCore/Extensions/KEFCoreEntityTypeBuilderExtensions.cs
+++ b/src/net/KEFCore/Extensions/KEFCoreEntityTypeBuilderExtensions.cs
@@ -269,25 +269,50 @@ public static class KEFCoreEntityTypeBuilderExtensions
     }
 
     /// <summary>
-    /// Configures in-memory result caching for full enumeration of this entity type's state store.
-    /// Equivalent to applying <see cref="KEFCoreValueBufferCacheAttribute"/> on the entity class.
+    /// Configures independent in-memory result caches for forward and reverse enumeration
+    /// of this entity type's Kafka Streams state store.
+    /// <para>
+    /// Forward cache: populated by the first complete <c>GetValueBuffers()</c> enumeration.
+    /// Also serves single key lookup and range queries when warm.
+    /// </para>
+    /// <para>
+    /// Reverse cache: populated by the first complete <c>GetValueBuffersReverse()</c>
+    /// enumeration. Also serves reverse range queries when warm.
+    /// </para>
     /// </summary>
-    /// <param name="builder">The <see cref="EntityTypeBuilder"/> to configure.</param>
-    /// <param name="ttl">Cache TTL for forward enumeration. Zero or negative disables caching.</param>
-    /// <param name="reverseTtl">
-    /// Cache TTL for reverse enumeration. <see langword="null"/> defaults to the same value as <paramref name="ttl"/>.
+    /// <param name="builder">The entity type builder.</param>
+    /// <param name="ttl">
+    /// TTL for the forward cache. Zero or negative disables it.
     /// </param>
-    /// <returns>The same <see cref="EntityTypeBuilder"/> for chaining.</returns>
+    /// <param name="reverseTtl">
+    /// TTL for the reverse cache. <see langword="null"/> defaults to the same value as
+    /// <paramref name="ttl"/>. Zero or negative disables it.
+    /// </param>
     public static EntityTypeBuilder HasKEFCoreValueBufferCache(
         this EntityTypeBuilder builder,
         TimeSpan ttl,
         TimeSpan? reverseTtl = null)
     {
+        ArgumentNullException.ThrowIfNull(builder);
+
         if (ttl > TimeSpan.Zero)
             builder.Metadata.SetAnnotation(KEFCoreAnnotationNames.ValueBufferCacheTtl, ttl);
-        var effectiveReverseTtl = reverseTtl ?? ttl;
-        if (effectiveReverseTtl > TimeSpan.Zero)
-            builder.Metadata.SetAnnotation(KEFCoreAnnotationNames.ValueBufferReverseCacheTtl, effectiveReverseTtl);
+
+        var effectiveReverse = reverseTtl ?? ttl;
+        if (effectiveReverse > TimeSpan.Zero)
+            builder.Metadata.SetAnnotation(KEFCoreAnnotationNames.ValueBufferReverseCacheTtl, effectiveReverse);
+
+        return builder;
+    }
+
+    /// <inheritdoc cref="HasKEFCoreValueBufferCache(EntityTypeBuilder,TimeSpan,TimeSpan?)"/>
+    public static EntityTypeBuilder<TEntity> HasKEFCoreValueBufferCache<TEntity>(
+        this EntityTypeBuilder<TEntity> builder,
+        TimeSpan ttl,
+        TimeSpan? reverseTtl = null)
+        where TEntity : class
+    {
+        ((EntityTypeBuilder)builder).HasKEFCoreValueBufferCache(ttl, reverseTtl);
         return builder;
     }
 }

--- a/src/net/KEFCore/Extensions/KEFCoreEntityTypeBuilderExtensions.cs
+++ b/src/net/KEFCore/Extensions/KEFCoreEntityTypeBuilderExtensions.cs
@@ -267,4 +267,27 @@ public static class KEFCoreEntityTypeBuilderExtensions
         builder.Metadata.SetAnnotation(KEFCoreAnnotationNames.TransactionGroup, transactionGroup);
         return builder;
     }
+
+    /// <summary>
+    /// Configures in-memory result caching for full enumeration of this entity type's state store.
+    /// Equivalent to applying <see cref="KEFCoreValueBufferCacheAttribute"/> on the entity class.
+    /// </summary>
+    /// <param name="builder">The <see cref="EntityTypeBuilder"/> to configure.</param>
+    /// <param name="ttl">Cache TTL for forward enumeration. Zero or negative disables caching.</param>
+    /// <param name="reverseTtl">
+    /// Cache TTL for reverse enumeration. <see langword="null"/> defaults to the same value as <paramref name="ttl"/>.
+    /// </param>
+    /// <returns>The same <see cref="EntityTypeBuilder"/> for chaining.</returns>
+    public static EntityTypeBuilder HasKEFCoreValueBufferCache(
+        this EntityTypeBuilder builder,
+        TimeSpan ttl,
+        TimeSpan? reverseTtl = null)
+    {
+        if (ttl > TimeSpan.Zero)
+            builder.Metadata.SetAnnotation(KEFCoreAnnotationNames.ValueBufferCacheTtl, ttl);
+        var effectiveReverseTtl = reverseTtl ?? ttl;
+        if (effectiveReverseTtl > TimeSpan.Zero)
+            builder.Metadata.SetAnnotation(KEFCoreAnnotationNames.ValueBufferReverseCacheTtl, effectiveReverseTtl);
+        return builder;
+    }
 }

--- a/src/net/KEFCore/Extensions/KEFCoreEntityTypeExtensions.cs
+++ b/src/net/KEFCore/Extensions/KEFCoreEntityTypeExtensions.cs
@@ -252,6 +252,23 @@ public static class KEFCoreEntityTypeExtensions
         => entityType.FindAnnotation(KEFCoreAnnotationNames.TransactionGroup)?.Value as string;
 
     /// <summary>
+    /// Returns the cache TTL for forward enumeration of this entity type's state store.
+    /// Returns <see cref="TimeSpan.Zero"/> if caching is not configured — the proxy
+    /// is a transparent pass-through with no allocation overhead.
+    /// </summary>
+    public static TimeSpan GetValueBufferCacheTtl(this IEntityType entityType)
+        => entityType.FindAnnotation(KEFCoreAnnotationNames.ValueBufferCacheTtl)?.Value as TimeSpan?
+           ?? TimeSpan.Zero;
+
+    /// <summary>
+    /// Returns the cache TTL for reverse enumeration of this entity type's state store.
+    /// Returns <see cref="TimeSpan.Zero"/> if caching is not configured.
+    /// </summary>
+    public static TimeSpan GetValueBufferReverseCacheTtl(this IEntityType entityType)
+        => entityType.FindAnnotation(KEFCoreAnnotationNames.ValueBufferReverseCacheTtl)?.Value as TimeSpan?
+           ?? TimeSpan.Zero;
+
+    /// <summary>
     /// Builds the <see cref="ConsumerConfigBuilder"/> for this entity type, merging the global
     /// <see cref="IKEFCoreSingletonOptions.ConsumerConfig"/> with any per-entity overrides
     /// stored as a <see cref="KEFCoreProducerAnnotation"/> annotation.

--- a/src/net/KEFCore/Extensions/KEFCoreEntityTypeExtensions.cs
+++ b/src/net/KEFCore/Extensions/KEFCoreEntityTypeExtensions.cs
@@ -252,21 +252,22 @@ public static class KEFCoreEntityTypeExtensions
         => entityType.FindAnnotation(KEFCoreAnnotationNames.TransactionGroup)?.Value as string;
 
     /// <summary>
-    /// Returns the cache TTL for forward enumeration of this entity type's state store.
-    /// Returns <see cref="TimeSpan.Zero"/> if caching is not configured — the proxy
-    /// is a transparent pass-through with no allocation overhead.
+    /// Returns the forward cache TTL for this entity type.
+    /// Returns <see cref="TimeSpan.Zero"/> when not configured (caching disabled).
     /// </summary>
     public static TimeSpan GetValueBufferCacheTtl(this IEntityType entityType)
-        => entityType.FindAnnotation(KEFCoreAnnotationNames.ValueBufferCacheTtl)?.Value as TimeSpan?
-           ?? TimeSpan.Zero;
+        => entityType.FindAnnotation(KEFCoreAnnotationNames.ValueBufferCacheTtl)?.Value is TimeSpan ttl
+            ? ttl
+            : TimeSpan.Zero;
 
     /// <summary>
-    /// Returns the cache TTL for reverse enumeration of this entity type's state store.
-    /// Returns <see cref="TimeSpan.Zero"/> if caching is not configured.
+    /// Returns the reverse cache TTL for this entity type.
+    /// Returns <see cref="TimeSpan.Zero"/> when not configured (reverse caching disabled).
     /// </summary>
     public static TimeSpan GetValueBufferReverseCacheTtl(this IEntityType entityType)
-        => entityType.FindAnnotation(KEFCoreAnnotationNames.ValueBufferReverseCacheTtl)?.Value as TimeSpan?
-           ?? TimeSpan.Zero;
+        => entityType.FindAnnotation(KEFCoreAnnotationNames.ValueBufferReverseCacheTtl)?.Value is TimeSpan ttl
+            ? ttl
+            : TimeSpan.Zero;
 
     /// <summary>
     /// Builds the <see cref="ConsumerConfigBuilder"/> for this entity type, merging the global

--- a/src/net/KEFCore/Metadata/Conventions/KEFCoreConventionSetBuilder.cs
+++ b/src/net/KEFCore/Metadata/Conventions/KEFCoreConventionSetBuilder.cs
@@ -67,6 +67,7 @@ IComplexTypeConverterFactory converterFactory) : ProviderConventionSetBuilder(de
         conventionSet.ModelFinalizingConventions.Add(new KEFCoreProducerConvention());
         conventionSet.ModelFinalizingConventions.Add(new KEFCoreTransactionalConvention());
         conventionSet.ModelFinalizingConventions.Add(new KEFCoreRocksDbLifecycleAttributeConvention());
+        conventionSet.ModelFinalizingConventions.Add(new KEFCoreValueBufferCacheConvention());
 
         return conventionSet;
     }

--- a/src/net/KEFCore/Metadata/Conventions/KEFCoreValueBufferCacheConvention.cs
+++ b/src/net/KEFCore/Metadata/Conventions/KEFCoreValueBufferCacheConvention.cs
@@ -1,30 +1,33 @@
 ﻿/*
-*  Copyright (c) 2022-2026 MASES s.r.l.
-*
-*  Licensed under the Apache License, Version 2.0 (the "License");
-*  you may not use this file except in compliance with the License.
-*  You may obtain a copy of the License at
-*
-*  http://www.apache.org/licenses/LICENSE-2.0
-*
-*  Unless required by applicable law or agreed to in writing, software
-*  distributed under the License is distributed on an "AS IS" BASIS,
-*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-*  See the License for the specific language governing permissions and
-*  limitations under the License.
-*
-*  Refer to LICENSE for more information.
-*/
+ * Copyright (c) 2022-2026 MASES s.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Refer to LICENSE for more information.
+ */
+
+#nullable enable
 
 using MASES.EntityFrameworkCore.KNet.Metadata.Internal;
 
 namespace MASES.EntityFrameworkCore.KNet.Metadata.Conventions;
 
 /// <summary>
-/// A convention that resolves per-entity value buffer cache configuration
-/// at model finalization time, storing the TTL values as model annotations.
+/// Resolves per-entity value buffer cache TTL configuration at model finalization time.
+/// Reads <see cref="KEFCoreValueBufferCacheAttribute"/> from the entity CLR type and
+/// stores forward and reverse TTLs as model annotations.
 /// </summary>
-public class KEFCoreValueBufferCacheConvention : IModelFinalizingConvention
+public sealed class KEFCoreValueBufferCacheConvention : IModelFinalizingConvention
 {
     /// <inheritdoc/>
     public void ProcessModelFinalizing(
@@ -33,12 +36,16 @@ public class KEFCoreValueBufferCacheConvention : IModelFinalizingConvention
     {
         foreach (var entityType in modelBuilder.Metadata.GetEntityTypes())
         {
-            var attr = entityType.ClrType.GetCustomAttribute<KEFCoreValueBufferCacheAttribute>();
-            if (attr == null) continue;
+            if (entityType.ClrType.GetCustomAttributes(typeof(KEFCoreValueBufferCacheAttribute), inherit: false)
+                                  .FirstOrDefault() is not KEFCoreValueBufferCacheAttribute attr) continue;
 
             var builder = (IConventionEntityTypeBuilder)entityType.Builder;
-            builder.HasAnnotation(KEFCoreAnnotationNames.ValueBufferCacheTtl, attr.Ttl);
-            builder.HasAnnotation(KEFCoreAnnotationNames.ValueBufferReverseCacheTtl, attr.ReverseTtl);
+
+            if (attr.Ttl > TimeSpan.Zero)
+                builder.HasAnnotation(KEFCoreAnnotationNames.ValueBufferCacheTtl, attr.Ttl);
+
+            if (attr.ReverseTtl > TimeSpan.Zero)
+                builder.HasAnnotation(KEFCoreAnnotationNames.ValueBufferReverseCacheTtl, attr.ReverseTtl);
         }
     }
 }

--- a/src/net/KEFCore/Metadata/Conventions/KEFCoreValueBufferCacheConvention.cs
+++ b/src/net/KEFCore/Metadata/Conventions/KEFCoreValueBufferCacheConvention.cs
@@ -1,0 +1,44 @@
+﻿/*
+*  Copyright (c) 2022-2026 MASES s.r.l.
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*  Refer to LICENSE for more information.
+*/
+
+using MASES.EntityFrameworkCore.KNet.Metadata.Internal;
+
+namespace MASES.EntityFrameworkCore.KNet.Metadata.Conventions;
+
+/// <summary>
+/// A convention that resolves per-entity value buffer cache configuration
+/// at model finalization time, storing the TTL values as model annotations.
+/// </summary>
+public class KEFCoreValueBufferCacheConvention : IModelFinalizingConvention
+{
+    /// <inheritdoc/>
+    public void ProcessModelFinalizing(
+        IConventionModelBuilder modelBuilder,
+        IConventionContext<IConventionModelBuilder> context)
+    {
+        foreach (var entityType in modelBuilder.Metadata.GetEntityTypes())
+        {
+            var attr = entityType.ClrType.GetCustomAttribute<KEFCoreValueBufferCacheAttribute>();
+            if (attr == null) continue;
+
+            var builder = (IConventionEntityTypeBuilder)entityType.Builder;
+            builder.HasAnnotation(KEFCoreAnnotationNames.ValueBufferCacheTtl, attr.Ttl);
+            builder.HasAnnotation(KEFCoreAnnotationNames.ValueBufferReverseCacheTtl, attr.ReverseTtl);
+        }
+    }
+}

--- a/src/net/KEFCore/Metadata/Internal/KEFCoreAnnotationNames.cs
+++ b/src/net/KEFCore/Metadata/Internal/KEFCoreAnnotationNames.cs
@@ -1,6 +1,3 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
 /*
 *  Copyright (c) 2022-2026 MASES s.r.l.
 *
@@ -184,5 +181,18 @@ public static class KEFCoreAnnotationNames
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public const string RocksDbLifecycleHandlerAnnotation = Prefix + "RocksDbLifecycleHandler";
-
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public const string ValueBufferCacheTtl = Prefix + "ValueBufferCacheTtl";
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public const string ValueBufferReverseCacheTtl = Prefix + "ValueBufferReverseCacheTtl";
 }

--- a/src/net/KEFCore/Metadata/KEFCoreValueBufferCacheAttribute.cs
+++ b/src/net/KEFCore/Metadata/KEFCoreValueBufferCacheAttribute.cs
@@ -1,57 +1,69 @@
 ﻿/*
-*  Copyright (c) 2022-2026 MASES s.r.l.
-*
-*  Licensed under the Apache License, Version 2.0 (the "License");
-*  you may not use this file except in compliance with the License.
-*  You may obtain a copy of the License at
-*
-*  http://www.apache.org/licenses/LICENSE-2.0
-*
-*  Unless required by applicable law or agreed to in writing, software
-*  distributed under the License is distributed on an "AS IS" BASIS,
-*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-*  See the License for the specific language governing permissions and
-*  limitations under the License.
-*
-*  Refer to LICENSE for more information.
-*/
+ * Copyright (c) 2022-2026 MASES s.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Refer to LICENSE for more information.
+ */
+
+#nullable enable
 
 namespace MASES.EntityFrameworkCore.KNet.Metadata;
 
 /// <summary>
-/// Configures in-memory result caching for full enumeration of this entity type's
-/// state store. When active, the first complete enumeration of <c>GetValueBuffers</c>
-/// or <c>GetValueBuffersReverse</c> populates an internal list; subsequent queries
-/// within the TTL window are served directly from that list — zero JNI cost.
-/// Partial enumerations (e.g. <c>First</c>, <c>Take</c>) never populate the cache.
-/// The cache is automatically invalidated when new data arrives from the cluster
-/// via <c>FreshEventChange</c>.
+/// Configures an in-memory result cache for this entity type's Kafka Streams state store.
+/// <para>
+/// Two independent caches are maintained: one for forward enumeration
+/// (<c>GetValueBuffers</c>, <c>GetValueBuffersRange</c>, single key lookup)
+/// and one for reverse enumeration (<c>GetValueBuffersReverse</c>,
+/// <c>GetValueBuffersReverseRange</c>). Each is backed by its own
+/// <see cref="SortedList{TKey,TValue}"/> and populated independently on the first
+/// complete enumeration in the respective direction.
+/// </para>
+/// <para>
+/// Partial enumerations (e.g. <c>First()</c>, <c>Take(n)</c>) never populate the cache.
+/// Both caches are invalidated automatically when new data arrives from the cluster via
+/// <c>FreshEventChange</c>.
+/// </para>
 /// </summary>
-[AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
 public sealed class KEFCoreValueBufferCacheAttribute : Attribute
 {
     /// <summary>
     /// Initializes a new instance of <see cref="KEFCoreValueBufferCacheAttribute"/>.
     /// </summary>
     /// <param name="ttlSeconds">
-    /// Cache TTL in seconds for forward enumeration (<c>GetValueBuffers</c>).
-    /// Zero or negative disables caching for forward enumeration.
+    /// Cache TTL in seconds for forward enumeration (<c>GetValueBuffers</c>, range, single key).
+    /// Zero or negative disables the forward cache — the proxy acts as a transparent
+    /// pass-through.
     /// </param>
     /// <param name="reverseTtlSeconds">
-    /// Cache TTL in seconds for reverse enumeration (<c>GetValueBuffersReverse</c>).
-    /// Zero or negative disables caching for reverse enumeration.
-    /// Defaults to the same value as <paramref name="ttlSeconds"/>.
+    /// Cache TTL in seconds for reverse enumeration (<c>GetValueBuffersReverse</c>,
+    /// reverse range). Zero or negative disables the reverse cache.
+    /// Defaults to <c>-1</c> which means: use the same value as
+    /// <paramref name="ttlSeconds"/>.
     /// </param>
     public KEFCoreValueBufferCacheAttribute(double ttlSeconds, double reverseTtlSeconds = -1)
     {
         Ttl = ttlSeconds > 0 ? TimeSpan.FromSeconds(ttlSeconds) : TimeSpan.Zero;
         ReverseTtl = reverseTtlSeconds >= 0
             ? TimeSpan.FromSeconds(reverseTtlSeconds)
-            : Ttl; // defaults to same as forward
+            : Ttl;
     }
 
-    /// <summary>Cache TTL for forward enumeration. <see cref="TimeSpan.Zero"/> disables caching.</summary>
+    /// <summary>TTL for forward cache. <see cref="TimeSpan.Zero"/> disables it.</summary>
     public TimeSpan Ttl { get; }
-    /// <summary>Cache TTL for reverse enumeration. <see cref="TimeSpan.Zero"/> disables caching.</summary>
+
+    /// <summary>TTL for reverse cache. <see cref="TimeSpan.Zero"/> disables it.</summary>
     public TimeSpan ReverseTtl { get; }
 }

--- a/src/net/KEFCore/Metadata/KEFCoreValueBufferCacheAttribute.cs
+++ b/src/net/KEFCore/Metadata/KEFCoreValueBufferCacheAttribute.cs
@@ -1,0 +1,57 @@
+﻿/*
+*  Copyright (c) 2022-2026 MASES s.r.l.
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*  Refer to LICENSE for more information.
+*/
+
+namespace MASES.EntityFrameworkCore.KNet.Metadata;
+
+/// <summary>
+/// Configures in-memory result caching for full enumeration of this entity type's
+/// state store. When active, the first complete enumeration of <c>GetValueBuffers</c>
+/// or <c>GetValueBuffersReverse</c> populates an internal list; subsequent queries
+/// within the TTL window are served directly from that list — zero JNI cost.
+/// Partial enumerations (e.g. <c>First</c>, <c>Take</c>) never populate the cache.
+/// The cache is automatically invalidated when new data arrives from the cluster
+/// via <c>FreshEventChange</c>.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+public sealed class KEFCoreValueBufferCacheAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="KEFCoreValueBufferCacheAttribute"/>.
+    /// </summary>
+    /// <param name="ttlSeconds">
+    /// Cache TTL in seconds for forward enumeration (<c>GetValueBuffers</c>).
+    /// Zero or negative disables caching for forward enumeration.
+    /// </param>
+    /// <param name="reverseTtlSeconds">
+    /// Cache TTL in seconds for reverse enumeration (<c>GetValueBuffersReverse</c>).
+    /// Zero or negative disables caching for reverse enumeration.
+    /// Defaults to the same value as <paramref name="ttlSeconds"/>.
+    /// </param>
+    public KEFCoreValueBufferCacheAttribute(double ttlSeconds, double reverseTtlSeconds = -1)
+    {
+        Ttl = ttlSeconds > 0 ? TimeSpan.FromSeconds(ttlSeconds) : TimeSpan.Zero;
+        ReverseTtl = reverseTtlSeconds >= 0
+            ? TimeSpan.FromSeconds(reverseTtlSeconds)
+            : Ttl; // defaults to same as forward
+    }
+
+    /// <summary>Cache TTL for forward enumeration. <see cref="TimeSpan.Zero"/> disables caching.</summary>
+    public TimeSpan Ttl { get; }
+    /// <summary>Cache TTL for reverse enumeration. <see cref="TimeSpan.Zero"/> disables caching.</summary>
+    public TimeSpan ReverseTtl { get; }
+}

--- a/src/net/KEFCore/Storage/Internal/EntityTypeProducer.cs
+++ b/src/net/KEFCore/Storage/Internal/EntityTypeProducer.cs
@@ -30,7 +30,6 @@ using MASES.KNet.Serialization;
 using Org.Apache.Kafka.Clients.Producer;
 using System.Collections;
 using System.Collections.Concurrent;
-using System.Linq;
 
 namespace MASES.EntityFrameworkCore.KNet.Storage.Internal;
 
@@ -91,118 +90,8 @@ public class EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContain
 
     #endregion
 
-    #region CachedValueBufferEnumerable
-
-    /// <summary>
-    /// Caching proxy over <see cref="IEnumerable{ValueBuffer}"/>.
-    /// When <paramref name="ttl"/> is <see cref="TimeSpan.Zero"/> or negative the proxy
-    /// is a transparent pass-through — no list is allocated, no data is retained.
-    /// Otherwise the first full enumeration populates an internal list; subsequent
-    /// enumerations within the TTL window return the list directly (zero JNI cost).
-    /// Call <see cref="Invalidate"/> to force a refresh on the next enumeration.
-    /// </summary>
-    /// <param name="source">Factory that produces a fresh upstream enumerator.</param>
-    /// <param name="ttl">Cache time-to-live. Zero or negative disables caching.</param>
-    internal sealed class CachedValueBufferEnumerable(Func<IEnumerable<ValueBuffer>> source, TimeSpan ttl) : IEnumerable<ValueBuffer>
-    {
-        private readonly Func<IEnumerable<ValueBuffer>> _source = source;
-        private readonly TimeSpan _ttl = ttl;
-        private readonly bool _cacheEnabled = ttl > TimeSpan.Zero;
-
-        private List<ValueBuffer>? _cache;
-        private DateTime _cacheExpiry = DateTime.MinValue;
-        private readonly object _lock = new();
-
-        /// <summary>
-        /// Marks the cache as expired. The next enumeration will re-fetch from the upstream source.
-        /// No-op when caching is disabled.
-        /// </summary>
-        public void Invalidate()
-        {
-            if (!_cacheEnabled) return;
-            lock (_lock)
-            {
-                _cache = null;
-                _cacheExpiry = DateTime.MinValue;
-            }
-        }
-
-        /// <inheritdoc/>
-        public IEnumerator<ValueBuffer> GetEnumerator()
-        {
-            // pass-through — no allocation, no caching
-            if (!_cacheEnabled)
-                return _source().GetEnumerator();
-
-            lock (_lock)
-            {
-                // cache hit
-                if (_cache != null && DateTime.UtcNow < _cacheExpiry)
-                    return _cache.GetEnumerator();
-
-                // cache miss — reset so the populating enumerator starts fresh
-                _cache = null;
-                _cacheExpiry = DateTime.MinValue;
-            }
-
-            // populate cache while caller enumerates
-            return new PopulatingEnumerator(this, _source());
-        }
-
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-
-        /// <summary>
-        /// Wraps the upstream enumerator: as each element is yielded it is added to
-        /// the parent's cache. On <see cref="Dispose"/> — whether the caller consumed
-        /// all elements or not — if the list is complete the expiry is set;
-        /// otherwise the partial list is discarded so the next call re-fetches.
-        /// </summary>
-        private sealed class PopulatingEnumerator(CachedValueBufferEnumerable parent, IEnumerable<ValueBuffer> source) : IEnumerator<ValueBuffer>
-        {
-            private readonly CachedValueBufferEnumerable _parent = parent;
-            private readonly IEnumerator<ValueBuffer> _inner = source.GetEnumerator();
-            private readonly List<ValueBuffer> _buffer = new();
-            private bool _completed = false;
-
-            public ValueBuffer Current => _inner.Current;
-            object IEnumerator.Current => Current;
-
-            public bool MoveNext()
-            {
-                if (!_inner.MoveNext())
-                {
-                    _completed = true;
-                    return false;
-                }
-                _buffer.Add(_inner.Current);
-                return true;
-            }
-
-            public void Reset() => throw new NotSupportedException();
-
-            public void Dispose()
-            {
-                _inner.Dispose();
-                lock (_parent._lock)
-                {
-                    if (_completed)
-                    {
-                        // full enumeration — commit to cache
-                        _parent._cache = _buffer;
-                        _parent._cacheExpiry = DateTime.UtcNow.Add(_parent._ttl);
-                    }
-                    else
-                    {
-                        // partial enumeration — discard, next call re-fetches
-                        _parent._cache = null;
-                        _parent._cacheExpiry = DateTime.MinValue;
-                    }
-                }
-            }
-        }
-    }
-
-    #endregion
+    // KEFCoreCachedValueBufferStore<TKey> lives in its own file:
+    // Storage/Internal/KEFCoreCachedValueBufferStore.cs
 
     private readonly IStreamsManager? _streamsManager;
 
@@ -219,8 +108,10 @@ public class EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContain
     private readonly IKEFCoreStreamsRetriever<TKey>? _streamData;
     private readonly ISerDes<TKey, TJVMKey>? _keySerdes;
     private readonly ISerDes<TValueContainer, TJVMValueContainer>? _valueSerdes;
-    private readonly CachedValueBufferEnumerable _cachedValueBuffers;
-    private readonly CachedValueBufferEnumerable _cachedValueBuffersReverse;
+    /// <summary>Forward cache — populated by GetValueBuffers(), serves range and single key.</summary>
+    private readonly KEFCoreCachedValueBufferStore<TKey> _forwardCache;
+    /// <summary>Reverse cache — populated by GetValueBuffersReverse(), serves reverse range.</summary>
+    private readonly KEFCoreCachedValueBufferStore<TKey> _reverseCache;
 
     readonly ConcurrentDictionary<IKEFCoreDatabase, KEFCoreDatabaseLocalData> _updaters = new();
     private readonly EntityTypeProducerCallback? _producerCallback;
@@ -437,8 +328,8 @@ public class EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContain
             _streamData = _database.Options.UseKNetStreams ? new KNetStreamsRetriever<TKey, TValueContainer, TJVMKey, TJVMValueContainer>(this, _entityMetadata, _complexTypeConverterFactory)
                                                            : new KafkaStreamsRetriever<TKey, TValueContainer, TJVMKey, TJVMValueContainer>(this, _entityMetadata, _complexTypeConverterFactory, _keySerdes!, _valueSerdes!);
 
-            _cachedValueBuffers = new CachedValueBufferEnumerable(() => _streamData!.GetValueBuffers(_database), _entityType.GetValueBufferCacheTtl());
-            _cachedValueBuffersReverse = new CachedValueBufferEnumerable(() => _streamData!.GetValueBuffersReverse(_database), _entityType.GetValueBufferReverseCacheTtl());
+            _forwardCache = new KEFCoreCachedValueBufferStore<TKey>(_primaryKey!, _keyValueFactory, _entityType.GetValueBufferCacheTtl());
+            _reverseCache = new KEFCoreCachedValueBufferStore<TKey>(_primaryKey!, _keyValueFactory, _entityType.GetValueBufferReverseCacheTtl());
         }
     }
 
@@ -662,7 +553,8 @@ public class EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContain
     /// <inheritdoc/>
     public IEnumerable<ValueBuffer> GetValueBuffers(IKEFCoreDatabase database)
     {
-        if (_streamData != null) return _cachedValueBuffers;
+        if (_streamData != null)
+            return _forwardCache.GetAllPopulating(() => _streamData.GetValueBuffers(_database));
         else if (_knetCompactedReplicator != null) return new KNetCompactedReplicatorEnumerable(_entityMetadata, _complexTypeConverterFactory, _knetCompactedReplicator);
         else throw new InvalidOperationException("Missing _knetCompactedReplicator or _streamData");
     }
@@ -670,15 +562,23 @@ public class EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContain
     public ValueBuffer? GetValueBuffer(IKEFCoreDatabase database, object?[]? keyValues)
     {
         if (keyValues == null) return null;
-        TKey? key = (TKey)_keyValueFactory.CreateFromKeyValues(keyValues)!;
-        if (key == null) return null;
         if (_streamData != null)
         {
-            return _streamData.TryGetValue(key, out var valueBuffer) ? valueBuffer : null;
+            // construct key only if forward cache is warm — avoids non-trivial key allocation
+            TKey? key = _forwardCache.IsWarm
+                ? (TKey)_keyValueFactory.CreateFromKeyValues(keyValues)!
+                : null;
+
+            if (key != null && _forwardCache.TryGetValue(key, out var cached))
+                return cached;
+
+            // cache cold, disabled, or key not found — fall back to store
+            key ??= (TKey)_keyValueFactory.CreateFromKeyValues(keyValues)!;
+            return key != null && _streamData.TryGetValue(key, out var vb) ? vb : null;
         }
         else if (_knetCompactedReplicator != null)
         {
-            return TryGetValueBuffer(key, out var buffer) ? buffer : null;
+            return TryGetValueBuffer((TKey)_keyValueFactory.CreateFromKeyValues(keyValues)!, out var buffer) ? buffer : null;
         }
         else throw new InvalidOperationException("Missing _knetCompactedReplicator or _streamData");
     }
@@ -687,6 +587,14 @@ public class EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContain
     {
         if (_streamData != null)
         {
+            // guard: build keys only if forward cache is warm — avoids non-trivial allocation
+            if (rangeStart != null && rangeEnd != null && _forwardCache.IsWarm)
+            {
+                TKey from = (TKey)_keyValueFactory.CreateFromKeyValues(rangeStart)!;
+                TKey to = (TKey)_keyValueFactory.CreateFromKeyValues(rangeEnd)!;
+                var cached = _forwardCache.TryGetRange(from, to);
+                if (cached != null) return cached;
+            }
             return _streamData.GetValueBuffersRange(database, _keyValueFactory, rangeStart, rangeEnd);
         }
         else if (_knetCompactedReplicator != null) throw new InvalidOperationException($"KNetCompactedReplicator does not support range iteration");
@@ -695,7 +603,10 @@ public class EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContain
     /// <inheritdoc/>
     public IEnumerable<ValueBuffer> GetValueBuffersReverse(IKEFCoreDatabase database)
     {
-        if (_streamData != null) return _cachedValueBuffersReverse;
+        if (_streamData != null)
+            // reverse cache: populated by this method, serves reverse range when warm.
+            // cold → native RocksDB reverse iterator (more efficient than any .NET alternative)
+            return _reverseCache.GetAllPopulating(() => _streamData.GetValueBuffersReverse(_database));
         else if (_knetCompactedReplicator != null) throw new InvalidOperationException($"KNetCompactedReplicator does not support reverse iteration");
         else throw new InvalidOperationException("Missing _knetCompactedReplicator or _streamData");
     }
@@ -704,6 +615,14 @@ public class EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContain
     {
         if (_streamData != null)
         {
+            // guard: build keys only if reverse cache is warm
+            if (rangeStart != null && rangeEnd != null && _reverseCache.IsWarm)
+            {
+                TKey from = (TKey)_keyValueFactory.CreateFromKeyValues(rangeStart)!;
+                TKey to = (TKey)_keyValueFactory.CreateFromKeyValues(rangeEnd)!;
+                var cached = _reverseCache.TryGetReverseRange(from, to);
+                if (cached != null) return cached;
+            }
             return _streamData.GetValueBuffersReverseRange(database, _keyValueFactory, rangeStart, rangeEnd);
         }
         else if (_knetCompactedReplicator != null) throw new InvalidOperationException($"KNetCompactedReplicator does not support reverse range iteration");
@@ -714,6 +633,13 @@ public class EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContain
     {
         if (_streamData != null)
         {
+            // try forward cache first if warm
+            if (prefixValues != null && _forwardCache.IsWarm)
+            {
+                TKey prefix = (TKey)_keyValueFactory.CreateFromKeyValues(prefixValues)!;
+                var cached = _forwardCache.TryGetPrefix(prefix, prefixValues.Length);
+                if (cached != null) return cached;
+            }
             return _streamData.GetValueBuffersByPrefix(database, _keyValueFactory, prefixValues);
         }
         else if (_knetCompactedReplicator != null) throw new InvalidOperationException($"KNetCompactedReplicator does not support prefix iteration");
@@ -755,8 +681,8 @@ public class EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContain
         if (offset.HasValue)
         {
             producer._streamsManager!.PartitionOffsetWritten(producer.EntityType.GetKEFCoreTopicName(), partiton, offset.Value);
-            producer._cachedValueBuffers.Invalidate();
-            producer._cachedValueBuffersReverse.Invalidate();
+            producer._forwardCache.Invalidate();
+            producer._reverseCache.Invalidate();
         }
     }
 

--- a/src/net/KEFCore/Storage/Internal/EntityTypeProducer.cs
+++ b/src/net/KEFCore/Storage/Internal/EntityTypeProducer.cs
@@ -64,6 +64,8 @@ public class EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContain
     where TKey : notnull
     where TValueContainer : class, IValueContainer<TKey>
 {
+    #region EntityTypeProducerCallback
+
     class EntityTypeProducerCallback(EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContainer> entityTypeProducer, Action<EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContainer>, int, long?, DateTime?, JVMBridgeException> result) : Callback
     {
         readonly EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContainer> _entityTypeProducer = entityTypeProducer;
@@ -75,6 +77,10 @@ public class EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContain
         }
     }
 
+    #endregion
+
+    #region TransactionalCallback
+
     class TransactionalCallback(ConcurrentQueue<(string topicName, int partition, long offset, JVMBridgeException? exception)> pendingOffsets) : Callback
     {
         public override void OnCompletion(RecordMetadata metadata, JVMBridgeException error)
@@ -82,6 +88,121 @@ public class EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContain
             pendingOffsets.Enqueue((metadata.Topic(), metadata.Partition(), metadata.Offset(), error));
         }
     }
+
+    #endregion
+
+    #region CachedValueBufferEnumerable
+
+    /// <summary>
+    /// Caching proxy over <see cref="IEnumerable{ValueBuffer}"/>.
+    /// When <paramref name="ttl"/> is <see cref="TimeSpan.Zero"/> or negative the proxy
+    /// is a transparent pass-through — no list is allocated, no data is retained.
+    /// Otherwise the first full enumeration populates an internal list; subsequent
+    /// enumerations within the TTL window return the list directly (zero JNI cost).
+    /// Call <see cref="Invalidate"/> to force a refresh on the next enumeration.
+    /// </summary>
+    /// <param name="source">Factory that produces a fresh upstream enumerator.</param>
+    /// <param name="ttl">Cache time-to-live. Zero or negative disables caching.</param>
+    internal sealed class CachedValueBufferEnumerable(Func<IEnumerable<ValueBuffer>> source, TimeSpan ttl) : IEnumerable<ValueBuffer>
+    {
+        private readonly Func<IEnumerable<ValueBuffer>> _source = source;
+        private readonly TimeSpan _ttl = ttl;
+        private readonly bool _cacheEnabled = ttl > TimeSpan.Zero;
+
+        private List<ValueBuffer>? _cache;
+        private DateTime _cacheExpiry = DateTime.MinValue;
+        private readonly object _lock = new();
+
+        /// <summary>
+        /// Marks the cache as expired. The next enumeration will re-fetch from the upstream source.
+        /// No-op when caching is disabled.
+        /// </summary>
+        public void Invalidate()
+        {
+            if (!_cacheEnabled) return;
+            lock (_lock)
+            {
+                _cache = null;
+                _cacheExpiry = DateTime.MinValue;
+            }
+        }
+
+        /// <inheritdoc/>
+        public IEnumerator<ValueBuffer> GetEnumerator()
+        {
+            // pass-through — no allocation, no caching
+            if (!_cacheEnabled)
+                return _source().GetEnumerator();
+
+            lock (_lock)
+            {
+                // cache hit
+                if (_cache != null && DateTime.UtcNow < _cacheExpiry)
+                    return _cache.GetEnumerator();
+
+                // cache miss — reset so the populating enumerator starts fresh
+                _cache = null;
+                _cacheExpiry = DateTime.MinValue;
+            }
+
+            // populate cache while caller enumerates
+            return new PopulatingEnumerator(this, _source());
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        /// <summary>
+        /// Wraps the upstream enumerator: as each element is yielded it is added to
+        /// the parent's cache. On <see cref="Dispose"/> — whether the caller consumed
+        /// all elements or not — if the list is complete the expiry is set;
+        /// otherwise the partial list is discarded so the next call re-fetches.
+        /// </summary>
+        private sealed class PopulatingEnumerator(CachedValueBufferEnumerable parent, IEnumerable<ValueBuffer> source) : IEnumerator<ValueBuffer>
+        {
+            private readonly CachedValueBufferEnumerable _parent = parent;
+            private readonly IEnumerator<ValueBuffer> _inner = source.GetEnumerator();
+            private readonly List<ValueBuffer> _buffer = new();
+            private bool _completed = false;
+
+            public ValueBuffer Current => _inner.Current;
+            object IEnumerator.Current => Current;
+
+            public bool MoveNext()
+            {
+                if (!_inner.MoveNext())
+                {
+                    _completed = true;
+                    return false;
+                }
+                _buffer.Add(_inner.Current);
+                return true;
+            }
+
+            public void Reset() => throw new NotSupportedException();
+
+            public void Dispose()
+            {
+                _inner.Dispose();
+                lock (_parent._lock)
+                {
+                    if (_completed)
+                    {
+                        // full enumeration — commit to cache
+                        _parent._cache = _buffer;
+                        _parent._cacheExpiry = DateTime.UtcNow.Add(_parent._ttl);
+                    }
+                    else
+                    {
+                        // partial enumeration — discard, next call re-fetches
+                        _parent._cache = null;
+                        _parent._cacheExpiry = DateTime.MinValue;
+                    }
+                }
+            }
+        }
+    }
+
+    #endregion
 
     private readonly IStreamsManager? _streamsManager;
 
@@ -98,6 +219,8 @@ public class EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContain
     private readonly IKEFCoreStreamsRetriever<TKey>? _streamData;
     private readonly ISerDes<TKey, TJVMKey>? _keySerdes;
     private readonly ISerDes<TValueContainer, TJVMValueContainer>? _valueSerdes;
+    private readonly CachedValueBufferEnumerable _cachedValueBuffers;
+    private readonly CachedValueBufferEnumerable _cachedValueBuffersReverse;
 
     readonly ConcurrentDictionary<IKEFCoreDatabase, KEFCoreDatabaseLocalData> _updaters = new();
     private readonly EntityTypeProducerCallback? _producerCallback;
@@ -313,6 +436,9 @@ public class EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContain
             }
             _streamData = _database.Options.UseKNetStreams ? new KNetStreamsRetriever<TKey, TValueContainer, TJVMKey, TJVMValueContainer>(this, _entityMetadata, _complexTypeConverterFactory)
                                                            : new KafkaStreamsRetriever<TKey, TValueContainer, TJVMKey, TJVMValueContainer>(this, _entityMetadata, _complexTypeConverterFactory, _keySerdes!, _valueSerdes!);
+
+            _cachedValueBuffers = new CachedValueBufferEnumerable(() => _streamData!.GetValueBuffers(_database), _entityType.GetValueBufferCacheTtl());
+            _cachedValueBuffersReverse = new CachedValueBufferEnumerable(() => _streamData!.GetValueBuffersReverse(_database), _entityType.GetValueBufferReverseCacheTtl());
         }
     }
 
@@ -536,7 +662,7 @@ public class EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContain
     /// <inheritdoc/>
     public IEnumerable<ValueBuffer> GetValueBuffers(IKEFCoreDatabase database)
     {
-        if (_streamData != null) return _streamData.GetValueBuffers(database);
+        if (_streamData != null) return _cachedValueBuffers;
         else if (_knetCompactedReplicator != null) return new KNetCompactedReplicatorEnumerable(_entityMetadata, _complexTypeConverterFactory, _knetCompactedReplicator);
         else throw new InvalidOperationException("Missing _knetCompactedReplicator or _streamData");
     }
@@ -569,7 +695,7 @@ public class EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContain
     /// <inheritdoc/>
     public IEnumerable<ValueBuffer> GetValueBuffersReverse(IKEFCoreDatabase database)
     {
-        if (_streamData != null) return _streamData.GetValueBuffersReverse(database);
+        if (_streamData != null) return _cachedValueBuffersReverse;
         else if (_knetCompactedReplicator != null) throw new InvalidOperationException($"KNetCompactedReplicator does not support reverse iteration");
         else throw new InvalidOperationException("Missing _knetCompactedReplicator or _streamData");
     }
@@ -626,7 +752,12 @@ public class EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContain
 
     private static void UpdateFromCommit(EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContainer> producer, int partiton, long? offset, DateTime? timestamp, JVMBridgeException error)
     {
-        if (offset.HasValue) producer._streamsManager!.PartitionOffsetWritten(producer.EntityType.GetKEFCoreTopicName(), partiton, offset.Value);
+        if (offset.HasValue)
+        {
+            producer._streamsManager!.PartitionOffsetWritten(producer.EntityType.GetKEFCoreTopicName(), partiton, offset.Value);
+            producer._cachedValueBuffers.Invalidate();
+            producer._cachedValueBuffersReverse.Invalidate();
+        }
     }
 
     /// <inheritdoc/>

--- a/src/net/KEFCore/Storage/Internal/KEFCoreCachedValueBufferStore.cs
+++ b/src/net/KEFCore/Storage/Internal/KEFCoreCachedValueBufferStore.cs
@@ -1,0 +1,416 @@
+﻿/*
+ * Copyright (c) 2022-2026 MASES s.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Refer to LICENSE for more information.
+ */
+
+#nullable enable
+
+using System.Collections;
+
+namespace MASES.EntityFrameworkCore.KNet.Storage.Internal;
+
+/// <summary>
+/// In-memory result cache for a Kafka Streams state store entity type.
+/// Backed by a <see cref="SortedList{TKey,TValue}"/> keyed on the entity primary key,
+/// using an <see cref="IComparer{T}"/> derived from <see cref="IKey"/> at construction
+/// time so that ordering matches the store's internal ordering.
+/// <para>
+/// The cache is populated lazily on the first <em>complete</em> forward enumeration
+/// (obtained via <see cref="GetAllPopulating"/>). Once warm, all access paths —
+/// forward, reverse, single key, range, reverse range, prefix — are served from the
+/// same sorted structure with zero JNI cost.
+/// </para>
+/// <para>
+/// Partial enumerations (caller disposes the enumerator before <c>MoveNext</c> returns
+/// <see langword="false"/>) discard any accumulated data — the next call re-fetches from
+/// the upstream source.
+/// </para>
+/// <para>
+/// When <paramref name="ttl"/> is <see cref="TimeSpan.Zero"/> or negative, caching is
+/// disabled: <see cref="GetAllPopulating"/> acts as a transparent pass-through and all
+/// <c>TryGet*</c> methods return <see langword="null"/> immediately.
+/// </para>
+/// </summary>
+internal sealed class KEFCoreCachedValueBufferStore<TKey>
+    where TKey : notnull
+{
+    // ── comparer for composite keys (object?[]) ──────────────────────────────
+    private sealed class CompositeKeyComparer(IReadOnlyList<IProperty> properties) : IComparer<TKey>
+    {
+        private readonly IReadOnlyList<IProperty> _properties = properties;
+
+        public int Compare(TKey? x, TKey? y)
+        {
+            if (x is object?[] xa && y is object?[] ya)
+            {
+                for (int i = 0; i < _properties.Count; i++)
+                {
+                    var c = Comparer<object?>.Default.Compare(xa[i], ya[i]);
+                    if (c != 0) return c;
+                }
+                return 0;
+            }
+            // fallback for non-array composite keys
+            return Comparer<TKey>.Default.Compare(x, y);
+        }
+    }
+
+    // ── populating enumerable returned from GetAllPopulating ─────────────────
+    private sealed class PopulatingEnumerable(
+        KEFCoreCachedValueBufferStore<TKey> store,
+        IEnumerable<ValueBuffer> source) : IEnumerable<ValueBuffer>
+    {
+        public IEnumerator<ValueBuffer> GetEnumerator()
+            => new PopulatingEnumerator(store, source);
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    private sealed class PopulatingEnumerator : IEnumerator<ValueBuffer>
+    {
+        private readonly KEFCoreCachedValueBufferStore<TKey> _store;
+        private readonly IEnumerator<ValueBuffer> _inner;
+        private readonly SortedList<TKey, ValueBuffer> _accumulator;
+        private bool _completed;
+
+        public PopulatingEnumerator(KEFCoreCachedValueBufferStore<TKey> store, IEnumerable<ValueBuffer> source)
+        {
+            _store = store;
+            _inner = source.GetEnumerator();
+            _accumulator = new SortedList<TKey, ValueBuffer>(store._comparer);
+        }
+
+        public ValueBuffer Current => _inner.Current;
+        object IEnumerator.Current => Current;
+
+        public bool MoveNext()
+        {
+            if (!_inner.MoveNext())
+            {
+                _completed = true;
+                return false;
+            }
+            // accumulate: extract key and copy ValueBuffer for independent ownership
+            var vb = _inner.Current;
+            var key = _store.ExtractKey(vb);
+            _accumulator[key] = CopyValueBuffer(vb);
+            return true;
+        }
+
+        public void Reset() => throw new NotSupportedException();
+
+        public void Dispose()
+        {
+            _inner.Dispose();
+            if (_completed)
+            {
+                // full enumeration completed — commit to cache
+                lock (_store._lock)
+                {
+                    _store._cache = _accumulator;
+                    _store._expiry = DateTime.UtcNow.Add(_store._ttl);
+                }
+            }
+            // partial enumeration — _accumulator is discarded, cache stays null/expired
+        }
+
+        /// <summary>
+        /// Copies the underlying object array of a <see cref="ValueBuffer"/> so that
+        /// each cached entry has independent ownership and is not affected by the caller
+        /// reusing the upstream buffer.
+        /// </summary>
+        private static ValueBuffer CopyValueBuffer(in ValueBuffer vb)
+        {
+            var arr = new object?[vb.Count];
+            for (int i = 0; i < arr.Length; i++) arr[i] = vb[i];
+            return new ValueBuffer(arr);
+        }
+    }
+
+    // ── state ─────────────────────────────────────────────────────────────────
+    private readonly TimeSpan _ttl;
+    private readonly bool _enabled;
+    private readonly IComparer<TKey> _comparer;
+    private readonly IKey _primaryKey;
+    private readonly IPrincipalKeyValueFactory<TKey> _keyValueFactory;
+
+    private SortedList<TKey, ValueBuffer>? _cache;
+    private DateTime _expiry = DateTime.MinValue;
+    private readonly object _lock = new();
+
+    // ── construction ──────────────────────────────────────────────────────────
+    public KEFCoreCachedValueBufferStore(
+        IKey primaryKey,
+        IPrincipalKeyValueFactory<TKey> keyValueFactory,
+        TimeSpan ttl)
+    {
+        _primaryKey = primaryKey;
+        _keyValueFactory = keyValueFactory;
+        _ttl = ttl;
+        _enabled = ttl > TimeSpan.Zero;
+        _comparer = primaryKey.Properties.Count == 1
+            ? Comparer<TKey>.Default
+            : new CompositeKeyComparer(primaryKey.Properties);
+    }
+
+    /// <summary><see langword="true"/> when caching is active (TTL &gt; zero).</summary>
+    public bool IsEnabled => _enabled;
+
+    // ── invalidation ──────────────────────────────────────────────────────────
+    /// <summary>
+    /// Marks the cache as expired. The next enumeration will re-fetch from the upstream
+    /// source. No-op when caching is disabled.
+    /// </summary>
+    public void Invalidate()
+    {
+        if (!_enabled) return;
+        lock (_lock)
+        {
+            _cache = null;
+            _expiry = DateTime.MinValue;
+        }
+    }
+
+    // ── key extraction ────────────────────────────────────────────────────────
+    private TKey ExtractKey(in ValueBuffer vb)
+    {
+        var props = _primaryKey.Properties;
+        var keyValues = new object?[props.Count];
+        for (int i = 0; i < props.Count; i++)
+            keyValues[i] = vb[props[i].GetIndex()];
+        return (TKey)_keyValueFactory.CreateFromKeyValues(keyValues)!;
+    }
+
+    // ── cache warm check ──────────────────────────────────────────────────────
+    /// <summary>
+    /// <see langword="true"/> when the cache is populated and the TTL has not expired.
+    /// Use this as a fast guard before constructing key objects — key construction has
+    /// a non-trivial cost and should be skipped when the cache is definitely cold.
+    /// </summary>
+    public bool IsWarm
+    {
+        get
+        {
+            if (!_enabled) return false;
+            lock (_lock) return _cache != null && DateTime.UtcNow < _expiry;
+        }
+    }
+
+    // private overload used inside methods that already hold _lock
+    private bool IsWarmUnsafe => _cache != null && DateTime.UtcNow < _expiry;
+
+    // ── public access API ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Returns an <see cref="IEnumerable{ValueBuffer}"/> for a full forward scan.
+    /// <list type="bullet">
+    ///   <item>Cache disabled — returns <paramref name="sourceFactory"/> directly (pass-through).</item>
+    ///   <item>Cache warm — returns <see cref="SortedList{TKey,TValue}.Values"/> directly.</item>
+    ///   <item>Cache cold — returns a <see cref="PopulatingEnumerable"/> that populates
+    ///         the cache when fully enumerated.</item>
+    /// </list>
+    /// </summary>
+    public IEnumerable<ValueBuffer> GetAllPopulating(Func<IEnumerable<ValueBuffer>> sourceFactory)
+    {
+        if (!_enabled) return sourceFactory();
+
+        lock (_lock)
+        {
+            if (IsWarmUnsafe) return _cache!.Values;
+            _cache = null;
+            _expiry = DateTime.MinValue;
+        }
+        return new PopulatingEnumerable(this, sourceFactory());
+    }
+
+    /// <summary>
+    /// Returns all values in reverse order.
+    /// Returns <see langword="null"/> when the cache is disabled or cold — caller should
+    /// fall back to the upstream source.
+    /// </summary>
+    public IEnumerable<ValueBuffer>? TryGetAllReverse()
+    {
+        if (!_enabled) return null;
+        lock (_lock)
+        {
+            if (!IsWarmUnsafe) return null;
+            // SortedList.Values is an IList<TValue> backed by an array —
+            // reverse by index: O(n), zero allocation
+            return ReverseValues(_cache!.Values);
+        }
+    }
+
+    private static IEnumerable<ValueBuffer> ReverseValues(IList<ValueBuffer> values)
+    {
+        for (int i = values.Count - 1; i >= 0; i--)
+            yield return values[i];
+    }
+
+    /// <summary>
+    /// Tries to retrieve a single entry by primary key from the cache.
+    /// Returns <see langword="false"/> when cache is disabled or cold — caller falls back.
+    /// </summary>
+    public bool TryGetValue(TKey key, out ValueBuffer valueBuffer)
+    {
+        if (_enabled)
+        {
+            lock (_lock)
+            {
+                if (IsWarmUnsafe)
+                    return _cache!.TryGetValue(key, out valueBuffer);
+            }
+        }
+        valueBuffer = default;
+        return false;
+    }
+
+    /// <summary>
+    /// Returns all values whose key falls within [<paramref name="from"/>, <paramref name="to"/>].
+    /// Returns <see langword="null"/> when cache is disabled or cold — caller falls back.
+    /// </summary>
+    public IEnumerable<ValueBuffer>? TryGetRange(TKey from, TKey to)
+    {
+        if (!_enabled) return null;
+        lock (_lock)
+        {
+            if (!IsWarmUnsafe) return null;
+            return RangeValues(_cache!, from, to, _comparer);
+        }
+    }
+
+    private static List<ValueBuffer> RangeValues(
+        SortedList<TKey, ValueBuffer> cache, TKey from, TKey to, IComparer<TKey> comparer)
+    {
+        var result = new List<ValueBuffer>();
+        // SortedList keys are sorted — find start index via binary search
+        var keys = cache.Keys;
+        int start = LowerBound(keys, from, comparer);
+        for (int i = start; i < keys.Count; i++)
+        {
+            if (comparer.Compare(keys[i], to) > 0) break;
+            result.Add(cache.Values[i]);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Returns all values in reverse order whose key falls within
+    /// [<paramref name="from"/>, <paramref name="to"/>].
+    /// Returns <see langword="null"/> when cache is disabled or cold — caller falls back.
+    /// </summary>
+    public IEnumerable<ValueBuffer>? TryGetReverseRange(TKey from, TKey to)
+    {
+        if (!_enabled) return null;
+        lock (_lock)
+        {
+            if (!IsWarmUnsafe) return null;
+            return ReverseRangeValues(_cache!, from, to, _comparer);
+        }
+    }
+
+    private static List<ValueBuffer> ReverseRangeValues(
+        SortedList<TKey, ValueBuffer> cache, TKey from, TKey to, IComparer<TKey> comparer)
+    {
+        var result = new List<ValueBuffer>();
+        var keys = cache.Keys;
+        // find the last key <= to
+        int end = UpperBound(keys, to, comparer);
+        for (int i = end; i >= 0; i--)
+        {
+            if (comparer.Compare(keys[i], from) < 0) break;
+            result.Add(cache.Values[i]);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Returns all values whose key starts with the given prefix components.
+    /// Returns <see langword="null"/> when cache is disabled or cold — caller falls back.
+    /// </summary>
+    public IEnumerable<ValueBuffer>? TryGetPrefix(TKey prefixKey, int prefixLength)
+    {
+        if (!_enabled) return null;
+        lock (_lock)
+        {
+            if (!IsWarmUnsafe) return null;
+            return PrefixValues(_cache!, prefixKey, prefixLength, _primaryKey.Properties);
+        }
+    }
+
+    private static List<ValueBuffer> PrefixValues(
+        SortedList<TKey, ValueBuffer> cache,
+        TKey prefixKey,
+        int prefixLength,
+        IReadOnlyList<IProperty> properties)
+    {
+        var result = new List<ValueBuffer>();
+        // Extract prefix components for matching
+        object?[]? prefixComponents = prefixKey is object?[] arr ? arr : null;
+
+        foreach (var kv in cache)
+        {
+            if (MatchesPrefix(kv.Key, prefixComponents, prefixLength, properties))
+                result.Add(kv.Value);
+        }
+        return result;
+    }
+
+    private static bool MatchesPrefix(
+        TKey key, object?[]? prefixComponents, int prefixLength,
+        IReadOnlyList<IProperty> properties)
+    {
+        if (prefixComponents == null)
+        {
+            // simple key — treat as string prefix if applicable
+            return key is string s && prefixComponents != null; // no-op for simple keys
+        }
+
+        if (key is not object?[] keyArr) return false;
+        for (int i = 0; i < prefixLength && i < keyArr.Length; i++)
+        {
+            if (!Equals(keyArr[i], prefixComponents[i])) return false;
+        }
+        return true;
+    }
+
+    // ── binary search helpers ─────────────────────────────────────────────────
+
+    /// <summary>Returns the index of the first element >= <paramref name="target"/>.</summary>
+    private static int LowerBound(IList<TKey> keys, TKey target, IComparer<TKey> comparer)
+    {
+        int lo = 0, hi = keys.Count;
+        while (lo < hi)
+        {
+            int mid = (lo + hi) >>> 1;
+            if (comparer.Compare(keys[mid], target) < 0) lo = mid + 1;
+            else hi = mid;
+        }
+        return lo;
+    }
+
+    /// <summary>Returns the index of the last element &lt;= <paramref name="target"/>, or -1.</summary>
+    private static int UpperBound(IList<TKey> keys, TKey target, IComparer<TKey> comparer)
+    {
+        int lo = 0, hi = keys.Count - 1, result = -1;
+        while (lo <= hi)
+        {
+            int mid = (lo + hi) >>> 1;
+            if (comparer.Compare(keys[mid], target) <= 0) { result = mid; lo = mid + 1; }
+            else hi = mid - 1;
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Introduce per-entity in-memory caching for full enumeration of value buffers. Adds KEFCoreValueBufferCacheAttribute and a KEFCoreValueBufferCacheConvention to read the attribute at model finalization and store TTL annotations (ValueBufferCacheTtl, ValueBufferReverseCacheTtl). Exposes builder and IEntityType helpers (HasKEFCoreValueBufferCache, GetValueBufferCacheTtl, GetValueBufferReverseCacheTtl). Implements CachedValueBufferEnumerable in EntityTypeProducer to populate and serve a list on first full enumeration and invalidate caches on commit; supports separate forward/reverse TTL and disables caching when TTL is zero. Wire the convention into KEFCoreConventionSetBuilder.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
