### PR TITLE
Update IValueContainer interface and adds internal cache

### DIFF
--- a/src/documentation/articles/serialization.md
+++ b/src/documentation/articles/serialization.md
@@ -143,9 +143,9 @@ The default serialization can be overridden with user defined **ValueContainer**
 A custom **ValueContainer** class must contains enough information and shall follow the following rules:
 - must implements the [`IValueContainer<T>` interface](https://github.com/masesgroup/KEFCore/blob/master/src/net/KEFCore.SerDes/IValueContainer.cs)
 - must be a generic type
-- must have at least a default constructor and a constructor which accept six parameters in this order:
+- must have at least a default constructor and a constructor which accept two parameters in this order:
   1. `IValueContainerData` -> the reference containing support information and data
-  6. `IComplexTypeConverterFactory?` -> an optional reference to the factory where the instance will retrieve specialized serializer, see [Complex type serialization](#complex-type-serialization)
+  2. `IComplexTypeConverterFactory?` -> an optional reference to the factory where the instance will retrieve specialized serializer, see [Complex type serialization](#complex-type-serialization)
 
 An example snippet is the follow:
 
@@ -184,19 +184,19 @@ public class CustomValueContainer<TKey> : IValueContainer<TKey> where TKey : not
     /// <summary>
     /// Returns back a dictionary of properties (PropertyName, Value) associated to the Entity
     /// </summary>
-    /// <param name="entityType">The <see cref="IEntityType"/> can be used to retrieve metadata, if <see langword="null"/> shall be done an inference from stored data</param>
+    /// <param name="metadata">The <see cref="IValueContainerMetadata"/> can be used to retrieve data, if <see langword="null"/> shall be done an inference from stored data</param>
     /// <returns>A dictionary of properties (PropertyName, Value) filled in with the data stored in the <see cref="IValueContainer{T}"/> instance</returns>
-    public IDictionary<string, object?> GetProperties(IEntityType? entityType)
+    public IDictionary<string, object?> GetProperties(IValueContainerMetadata? metadata)
     {
         // add specific logic
     }
     /// <summary>
     /// Returns back a dictionary of complex properties (PropertyName, Value) associated to the Entity
     /// </summary>
-    /// <param name="entityType">The <see cref="IEntityType"/> can be used to retrieve metadata, if <see langword="null"/> shall be done an inference from stored data</param>
+    /// <param name="metadata">The <see cref="IValueContainerMetadata"/> can be used to retrieve data, if <see langword="null"/> shall be done an inference from stored data</param>
     /// <param name="complexTypeFactory">The optional <see cref="IComplexTypeConverterFactory"/> instance to manage conversion of <see cref="IComplexType"/></param>
     /// <returns>A dictionary of properties (PropertyName, Value) filled in with the data stored in the <see cref="IValueContainer{T}"/> instance</returns>
-    public IDictionary<string, object?> GetComplexProperties(IEntityType? entityType, IComplexTypeConverterFactory? complexTypeFactory)
+    public IDictionary<string, object?> GetComplexProperties(IValueContainerMetadata? metadata, IComplexTypeConverterFactory? complexTypeFactory)
     {
         // add specific logic
     }

--- a/src/net/KEFCore.SerDes.Avro/AvroValueContainer.cs
+++ b/src/net/KEFCore.SerDes.Avro/AvroValueContainer.cs
@@ -22,6 +22,7 @@
 
 using MASES.KNet.Serialization;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Org.W3c.Dom.Ls;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 
@@ -268,6 +269,9 @@ public partial class AvroValueContainer<TKey> : AvroValueContainer, IValueContai
         }
     }
 
+    Dictionary<IPropertyBase, object>? propertiesInfo = null;
+    Dictionary<IComplexProperty, object>? complexPropertiesInfo = null;
+
     /// <inheritdoc/>
     public void GetData(IValueContainerMetadata metadata, ref object[] allPropertyValues, IComplexTypeConverterFactory? complexTypeFactory)
     {
@@ -287,46 +291,53 @@ public partial class AvroValueContainer<TKey> : AvroValueContainer, IValueContai
 #endif
             if (Data == null) { return; }
 #if DEBUG_PERFORMANCE
-            newSw.Start();
-#endif
-            allPropertyValues = new object[flattenedProperties!.Length];
-#if DEBUG_PERFORMANCE
-            newSw.Stop();
             iterationSw.Start();
 #endif
             if (complexProperties == null || complexProperties.Length == 0) // avoid complex flux without complex properties
             {
-                for (int i = 0; i < Data.Count; i++)
+                if (propertiesInfo != null)
                 {
-                    if (NativeTypeMapper.IsComplex(Data[i].ManagedType)) continue;
-
-                    IPropertyBase? prop = tName.FindProperty(Data[i].PropertyName!);
-                    if (prop == null) continue; // a property was removed from the schema 
-                    ConvertInnerData(Data[i], ref allPropertyValues[i]!, prop, complexTypeFactory);
+                    allPropertyValues = [.. propertiesInfo.Values];
+                }
+                else
+                {
+                    allPropertyValues = new object[flattenedProperties!.Length];
+                    propertiesInfo = [];
+                    for (int i = 0; i < Data.Count; i++)
+                    {
+                        if (NativeTypeMapper.IsComplex(Data[i].ManagedType)) continue;
+                        IPropertyBase? prop = tName.FindProperty(Data[i].PropertyName!);
+                        if (prop == null) continue; // a property was removed from the schema 
+                        ConvertInnerData(Data[i], ref allPropertyValues[i]!, prop, complexTypeFactory);
+                        propertiesInfo.Add(prop, allPropertyValues[i]!);
+                    }
                 }
             }
             else
             {
-                Dictionary<IPropertyBase, object> propertiesInfo = new();
-                Dictionary<IComplexProperty, object> complexPropertiesInfo = new();
-                for (int i = 0; i < Data.Count; i++)
+                if (propertiesInfo == null || complexPropertiesInfo == null)
                 {
-                    IPropertyBase? prop = NativeTypeMapper.IsComplex(Data[i].ManagedType)
-                         ? tName.FindComplexProperty(Data[i].PropertyName!)
-                         : tName.FindProperty(Data[i].PropertyName!);
-                    if (prop == null) continue; // a property was removed from the schema
-                    object input = null!;
-                    ConvertInnerData(Data[i], ref input!, prop, complexTypeFactory);
-                    if (prop is IComplexProperty complexProperty)
+                    propertiesInfo = [];
+                    complexPropertiesInfo = [];
+                    for (int i = 0; i < Data.Count; i++)
                     {
-                        complexPropertiesInfo.Add(complexProperty, input);
-                    }
-                    else
-                    {
-                        propertiesInfo.Add(prop, input);
+                        IPropertyBase? prop = NativeTypeMapper.IsComplex(Data[i].ManagedType)
+                             ? tName.FindComplexProperty(Data[i].PropertyName!)
+                             : tName.FindProperty(Data[i].PropertyName!);
+                        if (prop == null) continue; // a property was removed from the schema
+                        object input = null!;
+                        ConvertInnerData(Data[i], ref input!, prop, complexTypeFactory);
+                        if (prop is IComplexProperty complexProperty)
+                        {
+                            complexPropertiesInfo.Add(complexProperty, input);
+                        }
+                        else
+                        {
+                            propertiesInfo.Add(prop, input);
+                        }
                     }
                 }
-
+                allPropertyValues = new object[flattenedProperties!.Length];
                 flattenedProperties.FillFlattened(tName, propertiesInfo, complexPropertiesInfo, ref allPropertyValues);
             }
 #if DEBUG_PERFORMANCE
@@ -342,32 +353,84 @@ public partial class AvroValueContainer<TKey> : AvroValueContainer, IValueContai
         }
 #endif
     }
+    System.Collections.ObjectModel.ReadOnlyDictionary<string, object?>? outputProperties = null;
     /// <inheritdoc/>
-    public IDictionary<string, object?> GetProperties(IEntityType? entityType)
+    public IDictionary<string, object?> GetProperties(IValueContainerMetadata? metadata)
     {
-        Dictionary<string, object?> props = [];
+        if (outputProperties != null) return outputProperties;
+        if (propertiesInfo != null)
+        {
+            Dictionary<string, object?> dict = [];
+            foreach (var item in propertiesInfo)
+            {
+                dict.Add(item.Key.Name, item.Value);
+            }
+            outputProperties = new(dict);
+            return outputProperties;
+        }
+
+        if (metadata != null)
+        {
+            propertiesInfo = [];
+        }
+        Dictionary<string, object?> props = new();
         object? result = null!;
+        IPropertyBase? property = null;
         foreach (var item in Data)
         {
             if (NativeTypeMapper.IsComplex(item.ManagedType)) continue;
-            IPropertyBase property = entityType?.FindProperty(item.PropertyName!)!;
+            if (metadata != null)
+            {
+                property = metadata.EntityType?.FindProperty(item.PropertyName!)!;
+            }
             ConvertInnerData(item, ref result, property);
+            if (metadata != null && property != null)
+            {
+                propertiesInfo!.Add(property, result);
+            }
             props.Add(item.PropertyName, result);
         }
-        return new System.Collections.ObjectModel.ReadOnlyDictionary<string, object?>(props);
+        outputProperties = new(props);
+        return outputProperties;
     }
+    System.Collections.ObjectModel.ReadOnlyDictionary<string, object?>? outputComplexProperties = null;
     /// <inheritdoc/>
-    public IDictionary<string, object?> GetComplexProperties(IEntityType? entityType, IComplexTypeConverterFactory? complexTypeFactory)
+    public IDictionary<string, object?> GetComplexProperties(IValueContainerMetadata? metadata, IComplexTypeConverterFactory? complexTypeFactory)
     {
+        if (outputComplexProperties != null) return outputComplexProperties;
+        if (complexPropertiesInfo != null)
+        {
+            Dictionary<string, object?> dict = [];
+            foreach (var item in complexPropertiesInfo)
+            {
+                dict.Add(item.Key.Name, item.Value);
+            }
+            outputComplexProperties = new(dict);
+            return outputComplexProperties;
+        }
+
+        if (metadata != null)
+        {
+            complexPropertiesInfo = [];
+        }
         Dictionary<string, object?> props = [];
         object? result = null!;
+        IComplexProperty? property = null;
         foreach (var item in Data)
         {
             if (!NativeTypeMapper.IsComplex(item.ManagedType)) continue;
-            IPropertyBase property = entityType?.FindComplexProperty(item.PropertyName!)!;
+            if (metadata != null)
+            {
+                property = metadata?.EntityType?.FindComplexProperty(item.PropertyName!)!;
+            }
             ConvertInnerData(item, ref result, property, complexTypeFactory);
+            if (metadata != null && property != null)
+            {
+                complexPropertiesInfo!.Add(property, result);
+            }
             props.Add(item.PropertyName, result);
         }
-        return new System.Collections.ObjectModel.ReadOnlyDictionary<string, object?>(props);
+        outputComplexProperties = new(props);
+        return outputComplexProperties;
     }
 }

--- a/src/net/KEFCore.SerDes.Protobuf/Storage/ProtobufValueContainer.cs
+++ b/src/net/KEFCore.SerDes.Protobuf/Storage/ProtobufValueContainer.cs
@@ -116,6 +116,8 @@ public class ProtobufValueContainer<TKey> : IMessage<ProtobufValueContainer<TKey
     /// <inheritdoc/>
     public void WriteTo(CodedOutputStream output) => _innerMessage.WriteTo(output);
 
+    Dictionary<IPropertyBase, object>? propertiesInfo = null;
+    Dictionary<IComplexProperty, object>? complexPropertiesInfo = null;
     /// <inheritdoc/>
     public void GetData(IValueContainerMetadata metadata, ref object[] allPropertyValues, IComplexTypeConverterFactory? complexTypeFactory = null)
     {
@@ -144,40 +146,53 @@ public class ProtobufValueContainer<TKey> : IMessage<ProtobufValueContainer<TKey
 #endif
             if (complexProperties == null || complexProperties.Length == 0) // avoid complex flux without complex properties
             {
-                for (int i = 0; i < _innerMessage.Data.Count; i++)
+                if (propertiesInfo != null)
                 {
-                    var item = _innerMessage.Data[i];
-                    if (item == null) continue;
-                    if (NativeTypeMapper.IsComplex(item.Value.ManagedType)) continue;
-                    IPropertyBase? prop = tName.FindProperty(item.PropertyName!);
-                    if (prop == null) continue; // a property was removed from the schema 
-                    item.Value.GetContent(prop, complexTypeFactory, ref allPropertyValues[i]!);
+                    allPropertyValues = [.. propertiesInfo.Values];
+                }
+                else
+                {
+                    allPropertyValues = new object[flattenedProperties!.Length];
+                    propertiesInfo = [];
+                    for (int i = 0; i < _innerMessage.Data.Count; i++)
+                    {
+                        var item = _innerMessage.Data[i];
+                        if (item == null) continue;
+                        if (NativeTypeMapper.IsComplex(item.Value.ManagedType)) continue;
+                        IPropertyBase? prop = tName.FindProperty(item.PropertyName!);
+                        if (prop == null) continue; // a property was removed from the schema 
+                        item.Value.GetContent(prop, complexTypeFactory, ref allPropertyValues[i]!);
+                        propertiesInfo.Add(prop, allPropertyValues[i]!);
+                    }
                 }
             }
             else
             {
-                Dictionary<IPropertyBase, object> propertiesInfo = new();
-                Dictionary<IComplexProperty, object> complexPropertiesInfo = new();
-                for (int i = 0; i < _innerMessage.Data.Count; i++)
+                if (propertiesInfo == null || complexPropertiesInfo == null)
                 {
-                    var item = _innerMessage.Data[i];
-                    if (item == null) continue;
-                    IPropertyBase? prop = (NativeTypeMapper.IsComplex(item.Value.ManagedType))
-                        ? tName.FindComplexProperty(item.PropertyName!)
-                        : tName.FindProperty(item.PropertyName!);
-                    if (prop == null) continue; // a property was removed from the schema
-                    object input = null!;
-                    item.Value.GetContent(prop, complexTypeFactory, ref input!);
-                    if (prop is IComplexProperty complexProperty)
+                    propertiesInfo = [];
+                    complexPropertiesInfo = [];
+                    for (int i = 0; i < _innerMessage.Data.Count; i++)
                     {
-                        complexPropertiesInfo.Add(complexProperty, input);
-                    }
-                    else
-                    {
-                        propertiesInfo.Add(prop, input);
+                        var item = _innerMessage.Data[i];
+                        if (item == null) continue;
+                        IPropertyBase? prop = (NativeTypeMapper.IsComplex(item.Value.ManagedType))
+                            ? tName.FindComplexProperty(item.PropertyName!)
+                            : tName.FindProperty(item.PropertyName!);
+                        if (prop == null) continue; // a property was removed from the schema
+                        object input = null!;
+                        item.Value.GetContent(prop, complexTypeFactory, ref input!);
+                        if (prop is IComplexProperty complexProperty)
+                        {
+                            complexPropertiesInfo.Add(complexProperty, input);
+                        }
+                        else
+                        {
+                            propertiesInfo.Add(prop, input);
+                        }
                     }
                 }
-
+                allPropertyValues = new object[flattenedProperties!.Length];
                 flattenedProperties.FillFlattened(tName, propertiesInfo, complexPropertiesInfo, ref allPropertyValues);
             }
 #if DEBUG_PERFORMANCE
@@ -193,33 +208,87 @@ public class ProtobufValueContainer<TKey> : IMessage<ProtobufValueContainer<TKey
         }
 #endif
     }
+    System.Collections.ObjectModel.ReadOnlyDictionary<string, object?>? outputProperties = null;
     /// <inheritdoc/>
-    public IDictionary<string, object?> GetProperties(IEntityType? entityType)
+    public IDictionary<string, object?> GetProperties(IValueContainerMetadata? metadata)
     {
-        object? value = null;
+        if (outputProperties != null) return outputProperties;
+        if (propertiesInfo != null)
+        {
+            Dictionary<string, object?> dict = [];
+            foreach (var item in propertiesInfo)
+            {
+                dict.Add(item.Key.Name, item.Value);
+            }
+            outputProperties = new(dict);
+            return outputProperties;
+        }
+
+        if (metadata != null)
+        {
+            propertiesInfo = [];
+        }
+
+        object? result = null;
+        IPropertyBase? property = null;
         Dictionary<string, object?> props = [];
         foreach (var item in _innerMessage.Data)
         {
             if (NativeTypeMapper.IsComplex(item.Value.ManagedType)) continue;
-            IPropertyBase property = entityType?.FindProperty(item.PropertyName!)!;
-            item.Value.GetContent(property, null, ref value!);
-            props.Add(item.PropertyName, value);
+            if (metadata != null)
+            {
+                property = metadata.EntityType?.FindProperty(item.PropertyName!)!;
+            }
+            item.Value.GetContent(property, null, ref result!);
+            if (metadata != null && property != null)
+            {
+                propertiesInfo!.Add(property, result);
+            }
+            props.Add(item.PropertyName, result);
         }
-        return new System.Collections.ObjectModel.ReadOnlyDictionary<string, object?>(props);
+        outputProperties = new(props);
+        return outputProperties;
     }
+
+    System.Collections.ObjectModel.ReadOnlyDictionary<string, object?>? outputComplexProperties = null;
     /// <inheritdoc/>
-    public IDictionary<string, object?> GetComplexProperties(IEntityType? entityType, IComplexTypeConverterFactory? complexTypeFactory)
+    public IDictionary<string, object?> GetComplexProperties(IValueContainerMetadata? metadata, IComplexTypeConverterFactory? complexTypeFactory)
     {
-        object? value = null;
+        if (outputComplexProperties != null) return outputComplexProperties;
+        if (complexPropertiesInfo != null)
+        {
+            Dictionary<string, object?> dict = [];
+            foreach (var item in complexPropertiesInfo)
+            {
+                dict.Add(item.Key.Name, item.Value);
+            }
+            outputComplexProperties = new(dict);
+            return outputComplexProperties;
+        }
+
+        if (metadata != null)
+        {
+            complexPropertiesInfo = [];
+        }
         Dictionary<string, object?> props = [];
+        object? result = null!;
+        IComplexProperty? property = null;
         foreach (var item in _innerMessage.Data)
         {
             if (!NativeTypeMapper.IsComplex(item.Value.ManagedType)) continue;
-            IPropertyBase property = entityType?.FindComplexProperty(item.PropertyName!)!;
-            item.Value.GetContent(property, complexTypeFactory: complexTypeFactory, ref value!);
-            props.Add(item.PropertyName, value);
+            if (metadata != null)
+            {
+                property = metadata?.EntityType?.FindComplexProperty(item.PropertyName!)!;
+            }
+            item.Value.GetContent(property, complexTypeFactory: complexTypeFactory, ref result!);
+            if (metadata != null && property != null)
+            {
+                complexPropertiesInfo!.Add(property, result);
+            }
+            props.Add(item.PropertyName, result);
         }
-        return new System.Collections.ObjectModel.ReadOnlyDictionary<string, object?>(props);
+        outputComplexProperties = new(props);
+        return outputComplexProperties;
     }
     /// <inheritdoc/>
     public override bool Equals(object? obj)

--- a/src/net/KEFCore.SerDes/DefaultValueContainer.cs
+++ b/src/net/KEFCore.SerDes/DefaultValueContainer.cs
@@ -21,6 +21,7 @@
 #nullable enable
 
 using MASES.KNet.Serialization;
+using Org.Apache.Kafka.Clients;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -272,6 +273,12 @@ public class DefaultValueContainer<TKey> : IValueContainer<TKey> where TKey : no
     /// The data stored associated to the <see cref="IProperty"/> and <see cref="IComplexProperty"/> of <see cref="IEntityType"/>
     /// </summary>
     public PropertyData[]? Properties { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.Always)]
+    Dictionary<IPropertyBase, object>? propertiesInfo = null;
+    [JsonIgnore(Condition = JsonIgnoreCondition.Always)]
+    Dictionary<IComplexProperty, object>? complexPropertiesInfo = null;
+
     /// <inheritdoc/>
     public void GetData(IValueContainerMetadata metadata, ref object[] allPropertyValues, IComplexTypeConverterFactory? complexTypeFactory = null)
     {
@@ -294,64 +301,85 @@ public class DefaultValueContainer<TKey> : IValueContainer<TKey> where TKey : no
             newSw.Start();
 #endif
 
-            allPropertyValues = new object[flattenedProperties!.Length];
 #if DEBUG_PERFORMANCE
             newSw.Stop();
             iterationSw.Start();
 #endif
             if (Data != null)
             {
-                foreach (var item in Data!)
+                if (propertiesInfo != null)
                 {
-                    var prop = metadata.EntityType.FindProperty(item.Value?.PropertyName!);
-                    if (prop == null) continue; // a property was removed from the schema 
-                    allPropertyValues[item.Key] = item.Value?.Value!;
+                    allPropertyValues = [.. propertiesInfo.Values];
+                }
+                else
+                {
+                    allPropertyValues = new object[flattenedProperties!.Length];
+                    propertiesInfo = [];
+                    foreach (var item in Data!)
+                    {
+                        var prop = metadata.EntityType.FindProperty(item.Value?.PropertyName!);
+                        if (prop == null) continue; // a property was removed from the schema 
+                        allPropertyValues[item.Key] = item.Value?.Value!;
+                        propertiesInfo.Add(prop, allPropertyValues[item.Key]!);
+                    }
                 }
             }
             else
             {
                 if (complexProperties == null || complexProperties.Length == 0) // avoid complex flux without complex properties
                 {
-                    for (int i = 0; i < Properties.Length; i++)
+                    if (propertiesInfo != null)
                     {
-                        if (NativeTypeMapper.IsComplex(Properties[i].ManagedType)) continue;
-
-                        IPropertyBase? prop = tName.FindProperty(Properties[i].PropertyName!);
-                        if (prop == null) continue; // a property was removed from the schema
-                        allPropertyValues[i] = Properties[i]?.Value!;
+                        allPropertyValues = [.. propertiesInfo.Values];
+                    }
+                    else
+                    {
+                        allPropertyValues = new object[flattenedProperties!.Length];
+                        propertiesInfo = [];
+                        for (int i = 0; i < Properties.Length; i++)
+                        {
+                            if (NativeTypeMapper.IsComplex(Properties[i].ManagedType)) continue;
+                            IPropertyBase? prop = tName.FindProperty(Properties[i].PropertyName!);
+                            if (prop == null) continue; // a property was removed from the schema
+                            allPropertyValues[i] = Properties[i]?.Value!;
+                            propertiesInfo.Add(prop, allPropertyValues[i]!);
+                        }
                     }
                 }
                 else
                 {
-                    Dictionary<IPropertyBase, object> propertiesInfo = new();
-                    Dictionary<IComplexProperty, object> complexPropertiesInfo = new();
-                    for (int i = 0; i < Properties.Length; i++)
+                    if (propertiesInfo == null || complexPropertiesInfo == null)
                     {
-                        IPropertyBase? prop = NativeTypeMapper.IsComplex(Properties[i].ManagedType)
-                            ? tName.FindComplexProperty(Properties[i].PropertyName!)
-                            : tName.FindProperty(Properties[i].PropertyName!);
-                        if (prop == null) continue; // a property was removed from the schema
-                        if (prop is IComplexProperty complexProperty)
+                        propertiesInfo = [];
+                        complexPropertiesInfo = [];
+                        for (int i = 0; i < Properties.Length; i++)
                         {
-                            var input = Properties[i]?.Value!;
-                            if (Properties[i].ManagedType == WellKnownManagedTypes.ComplexTypeAsJson && input is string str)
+                            IPropertyBase? prop = NativeTypeMapper.IsComplex(Properties[i].ManagedType)
+                                ? tName.FindComplexProperty(Properties[i].PropertyName!)
+                                : tName.FindProperty(Properties[i].PropertyName!);
+                            if (prop == null) continue; // a property was removed from the schema
+                            if (prop is IComplexProperty complexProperty)
                             {
-                                input = JsonSupport.ValueContainer.Deserialize(prop.ClrType, str);
+                                var input = Properties[i]?.Value!;
+                                if (Properties[i].ManagedType == WellKnownManagedTypes.ComplexTypeAsJson && input is string str)
+                                {
+                                    input = JsonSupport.ValueContainer.Deserialize(prop.ClrType, str);
+                                }
+                                else if (Properties[i]?.ManagedType == WellKnownManagedTypes.ComplexType &&
+                                    complexTypeFactory != null && complexTypeFactory.TryGet(prop, out var complexTypeHook))
+                                {
+                                    complexTypeHook?.ConvertBack(PreferredConversionType.Text, ref input);
+                                }
+                                else throw new InvalidCastException($"Cannot manage record value {allPropertyValues[i]}.");
+                                complexPropertiesInfo.Add(complexProperty, input!);
                             }
-                            else if (Properties[i]?.ManagedType == WellKnownManagedTypes.ComplexType &&
-                                complexTypeFactory != null && complexTypeFactory.TryGet(prop, out var complexTypeHook))
+                            else
                             {
-                                complexTypeHook?.ConvertBack(PreferredConversionType.Text, ref input);
+                                propertiesInfo.Add(prop, Properties[i]?.Value!);
                             }
-                            else throw new InvalidCastException($"Cannot manage record value {allPropertyValues[i]}.");
-                            complexPropertiesInfo.Add(complexProperty, input!);
-                        }
-                        else
-                        {
-                            propertiesInfo.Add(prop, Properties[i]?.Value!);
                         }
                     }
-
+                    allPropertyValues = new object[flattenedProperties!.Length];
                     flattenedProperties.FillFlattened(tName, propertiesInfo, complexPropertiesInfo, ref allPropertyValues);
                 }
             }
@@ -368,10 +396,32 @@ public class DefaultValueContainer<TKey> : IValueContainer<TKey> where TKey : no
         }
 #endif
     }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.Always)]
+    System.Collections.ObjectModel.ReadOnlyDictionary<string, object?>? outputProperties = null;
     /// <inheritdoc/>
-    public IDictionary<string, object?> GetProperties(IEntityType? entityType)
+    public IDictionary<string, object?> GetProperties(IValueContainerMetadata? metadata)
     {
+        if (outputProperties != null) return outputProperties;
+        if (propertiesInfo != null)
+        {
+            Dictionary<string, object?> dict = [];
+            foreach (var item in propertiesInfo)
+            {
+                dict.Add(item.Key.Name, item.Value);
+            }
+            outputProperties = new(dict);
+            return outputProperties;
+        }
+
+        if (metadata != null)
+        {
+            propertiesInfo = [];
+        }
+
         Dictionary<string, object?> props = [];
+        object? result = null!;
+        IPropertyBase? property = null;
         if (Data == null && Properties == null) { return props; }
 
         if (Data != null)
@@ -379,43 +429,90 @@ public class DefaultValueContainer<TKey> : IValueContainer<TKey> where TKey : no
             // old implementation
             foreach (var item in Data!)
             {
+                if (metadata != null)
+                {
+                    property = metadata.EntityType?.FindProperty(item.Value.PropertyName!)!;
+                }
                 props.Add(item.Value.PropertyName!, item.Value.Value!);
+                if (metadata != null && property != null)
+                {
+                    propertiesInfo!.Add(property, result);
+                }
             }
-            return props;
+            outputProperties = new(props);
+            return outputProperties;
         }
-        object? value;
+
         foreach (var item in Properties!)
         {
-            value = item.Value!;
             if (NativeTypeMapper.IsComplex(item.ManagedType)) continue;
-            props.Add(item.PropertyName!, value);
+            if (metadata != null)
+            {
+                property = metadata.EntityType?.FindProperty(item.PropertyName!)!;
+            }
+            result = item.Value!;
+            if (metadata != null && property != null)
+            {
+                propertiesInfo!.Add(property, result);
+            }
+            props.Add(item.PropertyName!, result);
         }
-        return new System.Collections.ObjectModel.ReadOnlyDictionary<string, object?>(props);
+        outputProperties = new(props);
+        return outputProperties;
     }
 
+    [JsonIgnore(Condition = JsonIgnoreCondition.Always)]
+    System.Collections.ObjectModel.ReadOnlyDictionary<string, object?>? outputComplexProperties = null;
     /// <inheritdoc/>
-    public IDictionary<string, object?> GetComplexProperties(IEntityType? entityType, IComplexTypeConverterFactory? complexTypeFactory)
+    public IDictionary<string, object?> GetComplexProperties(IValueContainerMetadata? metadata, IComplexTypeConverterFactory? complexTypeFactory)
     {
+        if (outputComplexProperties != null) return outputComplexProperties;
+        if (complexPropertiesInfo != null)
+        {
+            Dictionary<string, object?> dict = [];
+            foreach (var item in complexPropertiesInfo)
+            {
+                dict.Add(item.Key.Name, item.Value);
+            }
+            outputComplexProperties = new(dict);
+            return outputComplexProperties;
+        }
+
+        if (metadata != null)
+        {
+            complexPropertiesInfo = [];
+        }
+
         Dictionary<string, object?> props = [];
+        object? result = null!;
+        IComplexProperty? property = null;
         if (Data == null && Properties == null) { return props; }
 
-        object? value;
         foreach (var item in Properties!)
         {
             if (!NativeTypeMapper.IsComplex(item.ManagedType)) continue;
-            value = item.Value!;
-            Type propertyType = entityType?.FindComplexProperty(item.PropertyName!)?.ClrType! ?? Type.GetType(item.ClrType!)!;
-            if (item.ManagedType == WellKnownManagedTypes.ComplexTypeAsJson && value is string str)
+            if (metadata != null)
             {
-                value = JsonSupport.ValueContainer.Deserialize(propertyType, str);
+                property = metadata?.EntityType?.FindComplexProperty(item.PropertyName!)!;
+            }
+            result = item.Value!;
+            Type propertyType = metadata?.EntityType?.FindComplexProperty(item.PropertyName!)?.ClrType! ?? Type.GetType(item.ClrType!)!;
+            if (item.ManagedType == WellKnownManagedTypes.ComplexTypeAsJson && result is string str)
+            {
+                result = JsonSupport.ValueContainer.Deserialize(propertyType, str);
             }
             else if (complexTypeFactory != null && complexTypeFactory.TryGet(propertyType, out IComplexTypeConverter? complexTypeHook))
             {
-                complexTypeHook?.ConvertBack(PreferredConversionType.Text, ref value!);
+                complexTypeHook?.ConvertBack(PreferredConversionType.Text, ref result!);
             }
-            else throw new InvalidCastException($"Cannot manage record value {value}.");
-            props.Add(item.PropertyName!, value);
+            else throw new InvalidCastException($"Cannot manage record value {result}.");
+            if (metadata != null && property != null)
+            {
+                complexPropertiesInfo!.Add(property, result);
+            }
+            props.Add(item.PropertyName!, result);
         }
-        return new System.Collections.ObjectModel.ReadOnlyDictionary<string, object?>(props);
+        outputComplexProperties = new(props);
+        return outputComplexProperties;
     }
 }

--- a/src/net/KEFCore.SerDes/IValueContainer.cs
+++ b/src/net/KEFCore.SerDes/IValueContainer.cs
@@ -44,14 +44,14 @@ public interface IValueContainer<in T> where T : notnull
     /// <summary>
     /// Returns back a dictionary of properties (PropertyName, Value) associated to the Entity
     /// </summary>
-    /// <param name="entityType">The <see cref="IEntityType"/> can be used to retrieve metadata, if <see langword="null"/> shall be done an inference from stored data</param>
+    /// <param name="metadata">The <see cref="IValueContainerMetadata"/> can be used to retrieve data, if <see langword="null"/> shall be done an inference from stored data</param>
     /// <returns>A dictionary of properties (PropertyName, Value) filled in with the data stored in the <see cref="IValueContainer{T}"/> instance</returns>
-    IDictionary<string, object?> GetProperties(IEntityType? entityType);
+    IDictionary<string, object?> GetProperties(IValueContainerMetadata? metadata);
     /// <summary>
     /// Returns back a dictionary of complex properties (PropertyName, Value) associated to the Entity
     /// </summary>
-    /// <param name="entityType">The <see cref="IEntityType"/> can be used to retrieve metadata, if <see langword="null"/> shall be done an inference from stored data</param>
+    /// <param name="metadata">The <see cref="IValueContainerMetadata"/> can be used to retrieve data, if <see langword="null"/> shall be done an inference from stored data</param>
     /// <param name="complexTypeFactory">The optional <see cref="IComplexTypeConverterFactory"/> instance to manage conversion of <see cref="IComplexType"/></param>
     /// <returns>A dictionary of properties (PropertyName, Value) filled in with the data stored in the <see cref="IValueContainer{T}"/> instance</returns>
-    IDictionary<string, object?> GetComplexProperties(IEntityType? entityType, IComplexTypeConverterFactory? complexTypeFactory);
+    IDictionary<string, object?> GetComplexProperties(IValueContainerMetadata? metadata, IComplexTypeConverterFactory? complexTypeFactory);
 }

--- a/src/net/KEFCore.SerDes/LocalEntityExtractor.cs
+++ b/src/net/KEFCore.SerDes/LocalEntityExtractor.cs
@@ -71,42 +71,38 @@ class LocalEntityExtractor<TKey, TValueContainer, TJVMKey, TJVMValueContainer, T
         if (recordValue == null) throw new ArgumentNullException(nameof(recordValue), "Record value shall be available");
 
         TValueContainer valueContainer = _valueSerdes?.DeserializeWithHeaders(topic, headers, recordValue)!;
-        var clrType = Type.GetType(valueContainer.ClrType, true);
-        if (clrType != null)
+        var clrType = Type.GetType(valueContainer.ClrType, true) ?? throw new ArgumentException($"Cannot create an instance of {valueContainer.ClrType}");
+        var entityType = (_model?.FindEntityType(clrType)) ?? throw new ArgumentException($"Cannot extract an IEntityType from {valueContainer.ClrType}");
+        var metadata = new ValueContainerMetadata(entityType!);
+        var newEntity = Activator.CreateInstance(clrType!);
+        foreach (var property in valueContainer.GetProperties(metadata))
         {
-            var entityType = _model?.FindEntityType(clrType);
-
-            var newEntity = Activator.CreateInstance(clrType!);
-            foreach (var property in valueContainer.GetProperties(entityType))
+            var propInfo = clrType.GetProperty(property.Key);
+            if (propInfo != null)
             {
-                var propInfo = clrType.GetProperty(property.Key);
-                if (propInfo != null)
-                {
-                    if (propInfo.CanWrite)
-                        propInfo.SetValue(newEntity, property.Value);
-                    else if (throwUnmatch)
-                        throw new InvalidOperationException($"Unable to write property {property.Value} at index {property.Key} with {property.Value}");
-                }
+                if (propInfo.CanWrite)
+                    propInfo.SetValue(newEntity, property.Value);
                 else if (throwUnmatch)
-                    throw new InvalidOperationException($"Property {property.Value} not found in {valueContainer.ClrType}");
+                    throw new InvalidOperationException($"Unable to write property {property.Value} at index {property.Key} with {property.Value}");
             }
-
-            foreach (var property in valueContainer.GetComplexProperties(entityType, _complexTypeFactory))
-            {
-                var propInfo = clrType.GetProperty(property.Key);
-                if (propInfo != null)
-                {
-                    if (propInfo.CanWrite)
-                        propInfo.SetValue(newEntity, property.Value);
-                    else if (throwUnmatch)
-                        throw new InvalidOperationException($"Unable to write property {property.Value} at index {property.Key} with {property.Value}");
-                }
-                else if (throwUnmatch)
-                    throw new InvalidOperationException($"Property {property.Value} not found in {valueContainer.ClrType}");
-            }
-
-            return newEntity!;
+            else if (throwUnmatch)
+                throw new InvalidOperationException($"Property {property.Value} not found in {valueContainer.ClrType}");
         }
-        throw new ArgumentException($"Cannot create an instance of {valueContainer.ClrType}");
+
+        foreach (var property in valueContainer.GetComplexProperties(metadata, _complexTypeFactory))
+        {
+            var propInfo = clrType.GetProperty(property.Key);
+            if (propInfo != null)
+            {
+                if (propInfo.CanWrite)
+                    propInfo.SetValue(newEntity, property.Value);
+                else if (throwUnmatch)
+                    throw new InvalidOperationException($"Unable to write property {property.Value} at index {property.Key} with {property.Value}");
+            }
+            else if (throwUnmatch)
+                throw new InvalidOperationException($"Property {property.Value} not found in {valueContainer.ClrType}");
+        }
+
+        return newEntity!;
     }
 }

--- a/src/net/KEFCore/Storage/Internal/EntityTypeProducer.cs
+++ b/src/net/KEFCore/Storage/Internal/EntityTypeProducer.cs
@@ -43,14 +43,15 @@ readonly struct KEFCoreDatabaseLocalData
         if (ManageEvents)
         {
             UpdateAdapter = database.UpdateAdapterFactory.Create();
-            EntityTypeForChanges = UpdateAdapter.Model.FindEntityType(entityType.ClrType)!;
-            PrimaryKeyForChanges = EntityTypeForChanges.FindPrimaryKey()!;
+            var entityType1 = UpdateAdapter.Model.FindEntityType(entityType.ClrType)!;
+            MetadataForChanges = new ValueContainerMetadata(entityType1);
+            PrimaryKeyForChanges = entityType1.FindPrimaryKey()!;
         }
     }
     public readonly IKEFCoreDatabase Database;
     public readonly bool ManageEvents;
     public readonly IUpdateAdapter? UpdateAdapter;
-    public readonly IEntityType? EntityTypeForChanges;
+    public readonly IValueContainerMetadata? MetadataForChanges;
     public readonly IKey? PrimaryKeyForChanges;
 }
 
@@ -95,7 +96,7 @@ public class EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContain
     private readonly IPrincipalKeyValueFactory<TKey> _keyValueFactory;
     private readonly IKNetCompactedReplicator<TKey, TValueContainer, TJVMKey, TJVMValueContainer>? _knetCompactedReplicator;
     private readonly IProducer<TKey, TValueContainer, TJVMKey, TJVMValueContainer>? _kafkaProducer;
-    private readonly IKEFCoreStreamsRetriever<TKey>? _streamData;
+    private readonly IKEFCoreStreamsRetriever<TKey, TValueContainer>? _streamData;
     private readonly ISerDes<TKey, TJVMKey>? _keySerdes;
     private readonly ISerDes<TValueContainer, TJVMValueContainer>? _valueSerdes;
 
@@ -354,9 +355,9 @@ public class EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContain
 
         if (_streamData != null)
         {
-            if (_streamData.TryGetProperties(key, out var properties, out var complexProperties))
+            if (_streamData.TryGetProperties(key, out var valueContainer))
             {
-                KEFCoreStateHelper.ManageFind(_database.InfrastructureLogger, _database.UpdateAdapterFactory, _entityType, _primaryKey!, keyValues, properties, complexProperties);
+                KEFCoreStateHelper.ManageFind(_database.InfrastructureLogger, _database.UpdateAdapterFactory, _entityMetadata, _primaryKey!, keyValues, valueContainer.GetProperties(_entityMetadata), valueContainer.GetComplexProperties(_entityMetadata, _complexTypeConverterFactory));
             }
             return;
         }
@@ -364,9 +365,9 @@ public class EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContain
         {
             if (_knetCompactedReplicator.TryGetValue(key, out var valueContainer))
             {
-                IDictionary<string, object?>? properties = valueContainer?.GetProperties(_entityType)!;
-                IDictionary<string, object?>? complexProperties = valueContainer?.GetComplexProperties(_entityType, _complexTypeConverterFactory)!;
-                KEFCoreStateHelper.ManageFind(_database.InfrastructureLogger, _database.UpdateAdapterFactory, _entityType, _primaryKey!, keyValues, properties, complexProperties);
+                IDictionary<string, object?>? properties = valueContainer?.GetProperties(_entityMetadata)!;
+                IDictionary<string, object?>? complexProperties = valueContainer?.GetComplexProperties(_entityMetadata, _complexTypeConverterFactory)!;
+                KEFCoreStateHelper.ManageFind(_database.InfrastructureLogger, _database.UpdateAdapterFactory, _entityMetadata, _primaryKey!, keyValues, properties, complexProperties);
             }
             return;
         }
@@ -374,24 +375,15 @@ public class EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContain
     }
 
     /// <inheritdoc/>
-    public bool TryGetProperties(TKey key, out IDictionary<string, object?> properties, out IDictionary<string, object?> complexProperties)
+    public bool TryGetProperties(TKey key, out TValueContainer valueContainer)
     {
         if (_streamData != null)
         {
-            return _streamData.TryGetProperties(key, out properties, out complexProperties);
+            return _streamData.TryGetProperties(key, out valueContainer);
         }
         else if (_knetCompactedReplicator != null)
         {
-            if (_knetCompactedReplicator.TryGetValue(key, out var valueContainer))
-            {
-                properties = valueContainer?.GetProperties(_entityType)!;
-                complexProperties = valueContainer?.GetComplexProperties(_entityType, _complexTypeConverterFactory)!;
-                return true;
-            }
-
-            properties = default!;
-            complexProperties = default!;
-            return false;
+            return _knetCompactedReplicator.TryGetValue(key, out valueContainer!);
         }
 
         throw new InvalidOperationException("Missing _knetCompactedReplicator or _streamData");
@@ -613,7 +605,7 @@ public class EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContain
                 KEFCoreDatabaseLocalData localData = new(database, _entityType);
                 foreach (var item in _knetCompactedReplicator)
                 {
-                    KEFCoreStateHelper.ManageAdded(database.InfrastructureLogger, database.Cluster.ValueGeneratorSelector, database.Cluster.ComplexTypeConverterFactory, localData.UpdateAdapter!, localData.EntityTypeForChanges!, localData.PrimaryKeyForChanges!, item.Key, item.Value);
+                    KEFCoreStateHelper.ManageAdded(database.InfrastructureLogger, database.Cluster.ValueGeneratorSelector, database.Cluster.ComplexTypeConverterFactory, localData.UpdateAdapter!, localData.MetadataForChanges!, localData.PrimaryKeyForChanges!, item.Key, item.Value);
                 }
             }
 #if DEBUG_PERFORMANCE
@@ -674,7 +666,7 @@ public class EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContain
         {
             IKEFCoreDatabase database = item.Key;
             KEFCoreDatabaseLocalData localData = item.Value;
-            KEFCoreStateHelper.ManageAdded(database.InfrastructureLogger, database.Cluster.ValueGeneratorSelector, database.Cluster.ComplexTypeConverterFactory, localData.UpdateAdapter!, localData.EntityTypeForChanges!, localData.PrimaryKeyForChanges!, arg2.Key, arg2.Value);
+            KEFCoreStateHelper.ManageAdded(database.InfrastructureLogger, database.Cluster.ValueGeneratorSelector, database.Cluster.ComplexTypeConverterFactory, localData.UpdateAdapter!, localData.MetadataForChanges!, localData.PrimaryKeyForChanges!, arg2.Key, arg2.Value);
         }
     }
 
@@ -684,7 +676,7 @@ public class EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContain
         {
             IKEFCoreDatabase database = item.Key;
             KEFCoreDatabaseLocalData localData = item.Value;
-            KEFCoreStateHelper.ManageUpdate(database.InfrastructureLogger, database.Cluster.ValueGeneratorSelector, database.Cluster.ComplexTypeConverterFactory, localData.UpdateAdapter!, localData.EntityTypeForChanges!, localData.PrimaryKeyForChanges!, arg2.Key, arg2.Value);
+            KEFCoreStateHelper.ManageUpdate(database.InfrastructureLogger, database.Cluster.ValueGeneratorSelector, database.Cluster.ComplexTypeConverterFactory, localData.UpdateAdapter!, localData.MetadataForChanges!, localData.PrimaryKeyForChanges!, arg2.Key, arg2.Value);
         }
     }
 
@@ -694,7 +686,7 @@ public class EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContain
         {
             IKEFCoreDatabase database = item.Key;
             KEFCoreDatabaseLocalData localData = item.Value;
-            KEFCoreStateHelper.ManageDelete(database.InfrastructureLogger, localData.UpdateAdapter!, localData.EntityTypeForChanges!, localData.PrimaryKeyForChanges!, arg2.Key);
+            KEFCoreStateHelper.ManageDelete(database.InfrastructureLogger, localData.UpdateAdapter!, localData.MetadataForChanges!, localData.PrimaryKeyForChanges!, arg2.Key);
         }
     }
 

--- a/src/net/KEFCore/Storage/Internal/IKEFCoreStreamsRetriever.cs
+++ b/src/net/KEFCore/Storage/Internal/IKEFCoreStreamsRetriever.cs
@@ -18,6 +18,8 @@
 
 #nullable enable
 
+using MASES.EntityFrameworkCore.KNet.Serialization;
+
 namespace MASES.EntityFrameworkCore.KNet.Storage.Internal;
 /// <summary>
 ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -25,16 +27,18 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-public interface IKEFCoreStreamsRetriever<TKey> : IDisposable where TKey : notnull
+public interface IKEFCoreStreamsRetriever<TKey, TValueContainer> : IDisposable 
+    where TKey : notnull
+    where TValueContainer : IValueContainer<TKey>
 {
     /// <summary>
-    /// Retrieve an <see cref="IEnumerable{ValueBuffer}"/> from the <see cref="IKEFCoreStreamsRetriever{TKey}"/> instance
+    /// Retrieve an <see cref="IEnumerable{ValueBuffer}"/> from the <see cref="IKEFCoreStreamsRetriever{TKey, TValueContainer}"/> instance
     /// </summary>
     /// <param name="database">The <see cref="IKEFCoreDatabase"/> requesting the data</param>
     /// <returns>An <see cref="IEnumerable{ValueBuffer}"/></returns>
     IEnumerable<ValueBuffer> GetValueBuffers(IKEFCoreDatabase database);
     /// <summary>
-    /// Retrieve an <see cref="IEnumerable{ValueBuffer}"/> in the range <paramref name="rangeStart"/>/<paramref name="rangeEnd"/> from the <see cref="IKEFCoreStreamsRetriever{TKey}"/> instance
+    /// Retrieve an <see cref="IEnumerable{ValueBuffer}"/> in the range <paramref name="rangeStart"/>/<paramref name="rangeEnd"/> from the <see cref="IKEFCoreStreamsRetriever{TKey, TValueContainer}"/> instance
     /// </summary>
     /// <param name="database">The <see cref="IKEFCoreDatabase"/> requesting the data</param>
     /// <param name="keyValueFactory">The key converter</param>
@@ -43,13 +47,13 @@ public interface IKEFCoreStreamsRetriever<TKey> : IDisposable where TKey : notnu
     /// <returns>An <see cref="IEnumerable{ValueBuffer}"/></returns>
     IEnumerable<ValueBuffer> GetValueBuffersRange(IKEFCoreDatabase database, IPrincipalKeyValueFactory<TKey> keyValueFactory, object?[]? rangeStart, object?[]? rangeEnd);
     /// <summary>
-    /// Retrieve a reverse order <see cref="IEnumerable{ValueBuffer}"/> from the <see cref="IKEFCoreStreamsRetriever{TKey}"/> instance
+    /// Retrieve a reverse order <see cref="IEnumerable{ValueBuffer}"/> from the <see cref="IKEFCoreStreamsRetriever{TKey, TValueContainer}"/> instance
     /// </summary>
     /// <param name="database">The <see cref="IKEFCoreDatabase"/> requesting the data</param>
     /// <returns>An <see cref="IEnumerable{ValueBuffer}"/></returns>
     IEnumerable<ValueBuffer> GetValueBuffersReverse(IKEFCoreDatabase database);
     /// <summary>
-    /// Retrieve an <see cref="IEnumerable{ValueBuffer}"/> in the reverse range <paramref name="rangeStart"/>/<paramref name="rangeEnd"/> from the <see cref="IKEFCoreStreamsRetriever{TKey}"/> instance
+    /// Retrieve an <see cref="IEnumerable{ValueBuffer}"/> in the reverse range <paramref name="rangeStart"/>/<paramref name="rangeEnd"/> from the <see cref="IKEFCoreStreamsRetriever{TKey, TValueContainer}"/> instance
     /// </summary>
     /// <param name="database">The <see cref="IKEFCoreDatabase"/> requesting the data</param>
     /// <param name="keyValueFactory">The key converter</param>
@@ -82,8 +86,7 @@ public interface IKEFCoreStreamsRetriever<TKey> : IDisposable where TKey : notnu
     /// Returns the values associated to the <paramref name="key"/>
     /// </summary>
     /// <param name="key">The key to retrieve</param>
-    /// <param name="properties">A <see cref="IDictionary{TKey, TValue}"/> containing the property name and associated value, or <see langword="null"/> otherwise</param>
-    /// <param name="complexProperties">A <see cref="IDictionary{TKey, TValue}"/> containing the complex property name and associated value, or <see langword="null"/> otherwise</param>
+    /// <param name="valueContainer">The <see cref="IValueContainer{T}"/> containing the properties associated to <paramref name="key"/>, or <see langword="null"/> otherwise</param>
     /// <returns><see langword="true"/> if the <paramref name="key"/> exist, <see langword="false"/> otherwise</returns>
-    bool TryGetProperties(TKey key, out IDictionary<string, object?> properties, out IDictionary<string, object?> complexProperties);
+    bool TryGetProperties(TKey key, out TValueContainer valueContainer);
 }

--- a/src/net/KEFCore/Storage/Internal/KEFCoreStateHelper.cs
+++ b/src/net/KEFCore/Storage/Internal/KEFCoreStateHelper.cs
@@ -31,7 +31,7 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
                 or ThreadInterruptedException;
         }
 
-        public static void ManageAdded<TKey, TValueContainer>(IDiagnosticsLogger<DbLoggerCategory.Infrastructure> logger, IValueGeneratorSelector valueGeneratorSelector, IComplexTypeConverterFactory converterFactory, IUpdateAdapterFactory factory, IEntityType entityType, IKey ikey, TKey key, TValueContainer container)
+        public static void ManageAdded<TKey, TValueContainer>(IDiagnosticsLogger<DbLoggerCategory.Infrastructure> logger, IValueGeneratorSelector valueGeneratorSelector, IComplexTypeConverterFactory converterFactory, IUpdateAdapterFactory factory, IValueContainerMetadata metadata, IKey ikey, TKey key, TValueContainer container)
             where TKey : notnull
             where TValueContainer : IValueContainer<TKey>
         {
@@ -53,10 +53,10 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
                 {
                     if (IsCriticalException(ex))
                     {
-                        logger.Logger.LogCritical(ex, "Failed to execute ManageDelete for {Entity} with Key={Key}: {Message}", entityType, key, ex.Message);
+                        logger.Logger.LogCritical(ex, "Failed to execute ManageDelete for {Entity} with Key={Key}: {Message}", metadata.EntityType, key, ex.Message);
                         throw;
                     }
-                    logger.Logger.LogError(ex, "Failed to execute ManageDelete for {Entity} with Key={Key}: {Message}", entityType, key, ex.Message);
+                    logger.Logger.LogError(ex, "Failed to execute ManageDelete for {Entity} with Key={Key}: {Message}", metadata.EntityType, key, ex.Message);
                 }
             }
             else
@@ -64,21 +64,21 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
                 logger.Logger.LogDebug("Record with key {key} added", key);
                 try
                 {
-                    ManageAddedInternal(logger, valueGeneratorSelector, adapter, entityType, ikey, keyValues, container.GetProperties(entityType), container.GetComplexProperties(entityType, converterFactory));
+                    ManageAddedInternal(logger, valueGeneratorSelector, adapter, metadata, ikey, keyValues, container.GetProperties(metadata), container.GetComplexProperties(metadata, converterFactory));
                 }
                 catch (Exception ex)
                 {
                     if (IsCriticalException(ex))
                     {
-                        logger.Logger.LogCritical(ex, "Failed to execute ManageDelete for {Entity} with Key={Key}: {Message}", entityType, key, ex.Message);
+                        logger.Logger.LogCritical(ex, "Failed to execute ManageDelete for {Entity} with Key={Key}: {Message}", metadata.EntityType, key, ex.Message);
                         throw;
                     }
-                    logger.Logger.LogError(ex, "Failed to execute ManageDelete for {Entity} with Key={Key}: {Message}", entityType, key, ex.Message);
+                    logger.Logger.LogError(ex, "Failed to execute ManageDelete for {Entity} with Key={Key}: {Message}", metadata.EntityType, key, ex.Message);
                 }
             }
         }
 
-        public static void ManageAdded<TKey, TValueContainer>(IDiagnosticsLogger<DbLoggerCategory.Infrastructure> logger, IValueGeneratorSelector valueGeneratorSelector, IComplexTypeConverterFactory converterFactory, IUpdateAdapter adapter, IEntityType entityType, IKey ikey, TKey key, TValueContainer container)
+        public static void ManageAdded<TKey, TValueContainer>(IDiagnosticsLogger<DbLoggerCategory.Infrastructure> logger, IValueGeneratorSelector valueGeneratorSelector, IComplexTypeConverterFactory converterFactory, IUpdateAdapter adapter, IValueContainerMetadata metadata, IKey ikey, TKey key, TValueContainer container)
             where TKey : notnull
             where TValueContainer : IValueContainer<TKey>
         {
@@ -90,32 +90,32 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
             }
             try
             {
-                ManageAddedInternal(logger, valueGeneratorSelector, adapter, entityType, ikey, keyValues, container.GetProperties(entityType), container.GetComplexProperties(entityType, converterFactory));
+                ManageAddedInternal(logger, valueGeneratorSelector, adapter, metadata, ikey, keyValues, container.GetProperties(metadata), container.GetComplexProperties(metadata, converterFactory));
             }
             catch (Exception ex)
             {
                 if (IsCriticalException(ex))
                 {
-                    logger.Logger.LogCritical(ex, "Failed to execute ManageAddedInternal for {Entity} with Key={Key}: {Message}", entityType, key, ex.Message);
+                    logger.Logger.LogCritical(ex, "Failed to execute ManageAddedInternal for {Entity} with Key={Key}: {Message}", metadata.EntityType, key, ex.Message);
                     throw;
                 }
-                logger.Logger.LogError(ex, "Failed to execute ManageAddedInternal for {Entity} with Key={Key}: {Message}", entityType, key, ex.Message);
+                logger.Logger.LogError(ex, "Failed to execute ManageAddedInternal for {Entity} with Key={Key}: {Message}", metadata.EntityType, key, ex.Message);
             }
         }
 
-        static void ManageAddedInternal(IDiagnosticsLogger<DbLoggerCategory.Infrastructure> logger, IValueGeneratorSelector valueGeneratorSelector, IUpdateAdapter adapter, IEntityType entityType, IKey ikey, object?[] keyValues, IDictionary<string, object?> propertyValues, IDictionary<string, object?> complexPropertyValues)
+        static void ManageAddedInternal(IDiagnosticsLogger<DbLoggerCategory.Infrastructure> logger, IValueGeneratorSelector valueGeneratorSelector, IUpdateAdapter adapter, IValueContainerMetadata metadata, IKey ikey, object?[] keyValues, IDictionary<string, object?> propertyValues, IDictionary<string, object?> complexPropertyValues)
         {
             IUpdateEntry? entry = adapter.TryGetEntry(ikey, keyValues);
             if (entry == null)
             {
                 logger.Logger.LogDebug("ManageAddedInternal: Record not available, adding");
-                var properties = entityType.GetValueGeneratingProperties();
+                var properties = metadata.EntityType.GetValueGeneratingProperties();
                 foreach (var item in properties)
                 {
 #if NET9_0 || NET10_0
-                    if (!valueGeneratorSelector.TrySelect(item, entityType, out ValueGenerator? valueGenerator)) valueGenerator = null;
+                    if (!valueGeneratorSelector.TrySelect(item, metadata.EntityType, out ValueGenerator? valueGenerator)) valueGenerator = null;
 #else
-                    ValueGenerator? valueGenerator = valueGeneratorSelector?.Select(item, entityType);
+                    ValueGenerator? valueGenerator = valueGeneratorSelector?.Select(item, metadata.EntityType);
 #endif
                     if (valueGenerator is IKEFCoreValueGenerator iKEFCoreGenerator)
                     {
@@ -123,7 +123,7 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
                     }
                 }
                 // the key does not exist
-                var newEntry = adapter.CreateEntry(propertyValues, entityType);
+                var newEntry = adapter.CreateEntry(propertyValues, metadata.EntityType);
                 var entityEntry = newEntry.ToEntityEntry();
                 foreach (var item in entityEntry.ComplexProperties)
                 {
@@ -141,7 +141,7 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
             }
         }
 
-        public static void ManageUpdate<TKey, TValueContainer>(IDiagnosticsLogger<DbLoggerCategory.Infrastructure> logger, IValueGeneratorSelector valueGeneratorSelector, IComplexTypeConverterFactory converterFactory, IUpdateAdapterFactory factory, IEntityType entityType, IKey ikey, TKey key, TValueContainer container)
+        public static void ManageUpdate<TKey, TValueContainer>(IDiagnosticsLogger<DbLoggerCategory.Infrastructure> logger, IValueGeneratorSelector valueGeneratorSelector, IComplexTypeConverterFactory converterFactory, IUpdateAdapterFactory factory, IValueContainerMetadata metadata, IKey ikey, TKey key, TValueContainer container)
             where TKey : notnull
             where TValueContainer : class, IValueContainer<TKey>
         {
@@ -154,8 +154,8 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
 
             var adapter = factory.Create();
             IUpdateEntry? entry = adapter.TryGetEntry(ikey, keyValues);
-            var properties = container.GetProperties(entityType);
-            var complexProperties = container.GetComplexProperties(entityType, converterFactory);
+            var properties = container.GetProperties(metadata);
+            var complexProperties = container.GetComplexProperties(metadata, converterFactory);
             if (entry != null)
             {
                 try
@@ -167,10 +167,10 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
                 {
                     if (IsCriticalException(ex))
                     {
-                        logger.Logger.LogCritical(ex, "Failed to execute ManageUpdateInternal for {Entity} with Key={Key}: {Message}", entityType, key, ex.Message);
+                        logger.Logger.LogCritical(ex, "Failed to execute ManageUpdateInternal for {Entity} with Key={Key}: {Message}", metadata.EntityType, key, ex.Message);
                         throw;
                     }
-                    logger.Logger.LogError(ex, "Failed to execute ManageUpdateInternal for {Entity} with Key={Key}: {Message}", entityType, key, ex.Message);
+                    logger.Logger.LogError(ex, "Failed to execute ManageUpdateInternal for {Entity} with Key={Key}: {Message}", metadata.EntityType, key, ex.Message);
                 }
             }
             else
@@ -178,21 +178,21 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
                 try
                 {
                     logger.Logger.LogDebug("ManageUpdate: Record with key {key} does not exists, add", key);
-                    ManageAddedInternal(logger, valueGeneratorSelector, adapter, entityType, ikey, keyValues, properties, complexProperties);
+                    ManageAddedInternal(logger, valueGeneratorSelector, adapter, metadata, ikey, keyValues, properties, complexProperties);
                 }
                 catch (Exception ex)
                 {             
                     if (IsCriticalException(ex))
                     {
-                        logger.Logger.LogCritical(ex, "Failed to execute ManageAddedInternal for {Entity} with Key={Key}: {Message}", entityType, key, ex.Message);
+                        logger.Logger.LogCritical(ex, "Failed to execute ManageAddedInternal for {Entity} with Key={Key}: {Message}", metadata.EntityType, key, ex.Message);
                         throw;
                     }
-                    logger.Logger.LogError(ex, "Failed to execute ManageAddedInternal for {Entity} with Key={Key}: {Message}", entityType, key, ex.Message);
+                    logger.Logger.LogError(ex, "Failed to execute ManageAddedInternal for {Entity} with Key={Key}: {Message}", metadata.EntityType, key, ex.Message);
                 }
             }
         }
 
-        public static void ManageUpdate<TKey, TValueContainer>(IDiagnosticsLogger<DbLoggerCategory.Infrastructure> logger, IValueGeneratorSelector valueGeneratorSelector, IComplexTypeConverterFactory converterFactory, IUpdateAdapter adapter, IEntityType entityType, IKey ikey, TKey key, TValueContainer container)
+        public static void ManageUpdate<TKey, TValueContainer>(IDiagnosticsLogger<DbLoggerCategory.Infrastructure> logger, IValueGeneratorSelector valueGeneratorSelector, IComplexTypeConverterFactory converterFactory, IUpdateAdapter adapter, IValueContainerMetadata metadata, IKey ikey, TKey key, TValueContainer container)
             where TKey : notnull
             where TValueContainer : class, IValueContainer<TKey>
         {
@@ -204,8 +204,8 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
             }
 
             IUpdateEntry? entry = adapter.TryGetEntry(ikey, keyValues);
-            var properties = container.GetProperties(entityType);
-            var complexProperties = container.GetComplexProperties(entityType, converterFactory);
+            var properties = container.GetProperties(metadata);
+            var complexProperties = container.GetComplexProperties(metadata, converterFactory);
             if (entry != null)
             {
                 try
@@ -217,10 +217,10 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
                 {
                     if (IsCriticalException(ex))
                     {
-                        logger.Logger.LogCritical(ex, "Failed to execute ManageUpdateInternal for {Entity} with Key={Key}: {Message}", entityType, key, ex.Message);
+                        logger.Logger.LogCritical(ex, "Failed to execute ManageUpdateInternal for {Entity} with Key={Key}: {Message}", metadata.EntityType, key, ex.Message);
                         throw;
                     }
-                    logger.Logger.LogError(ex, "Failed to execute ManageUpdateInternal for {Entity} with Key={Key}: {Message}", entityType, key, ex.Message);
+                    logger.Logger.LogError(ex, "Failed to execute ManageUpdateInternal for {Entity} with Key={Key}: {Message}", metadata.EntityType, key, ex.Message);
                 }
             }
             else
@@ -228,16 +228,16 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
                 try
                 {
                     logger.Logger.LogDebug("ManageUpdate: Record does not exists, add");
-                    ManageAddedInternal(logger, valueGeneratorSelector, adapter, entityType, ikey, keyValues, properties, complexProperties);
+                    ManageAddedInternal(logger, valueGeneratorSelector, adapter, metadata, ikey, keyValues, properties, complexProperties);
                 }
                 catch (Exception ex)
                 {         
                     if (IsCriticalException(ex))
                     {
-                        logger.Logger.LogCritical(ex, "Failed to execute ManageAddedInternal for {Entity} with Key={Key}: {Message}", entityType, key, ex.Message);
+                        logger.Logger.LogCritical(ex, "Failed to execute ManageAddedInternal for {Entity} with Key={Key}: {Message}", metadata.EntityType, key, ex.Message);
                         throw;
                     }
-                    logger.Logger.LogError(ex, "Failed to execute ManageAddedInternal for {Entity} with Key={Key}: {Message}", entityType, key, ex.Message);
+                    logger.Logger.LogError(ex, "Failed to execute ManageAddedInternal for {Entity} with Key={Key}: {Message}", metadata.EntityType, key, ex.Message);
                 }
             }
         }
@@ -276,7 +276,7 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
             }
         }
 
-        public static void ManageDelete<TKey>(IDiagnosticsLogger<DbLoggerCategory.Infrastructure> logger, IUpdateAdapterFactory factory, IEntityType entityType, IKey ikey, TKey key)
+        public static void ManageDelete<TKey>(IDiagnosticsLogger<DbLoggerCategory.Infrastructure> logger, IUpdateAdapterFactory factory, IValueContainerMetadata metadata, IKey ikey, TKey key)
             where TKey : notnull
         {
             if (key is not object?[] keyValues)
@@ -293,14 +293,14 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
             {
                 if (IsCriticalException(ex))
                 {
-                    logger.Logger.LogCritical(ex, "Failed to execute ManageDeleteInternal for {Entity} with Key={Key}: {Message}", entityType, key, ex.Message);
+                    logger.Logger.LogCritical(ex, "Failed to execute ManageDeleteInternal for {Entity} with Key={Key}: {Message}", metadata.EntityType, key, ex.Message);
                     throw;
                 }
-                logger.Logger.LogError(ex, "Failed to execute ManageDeleteInternal for {Entity} with Key={Key}: {Message}", entityType, key, ex.Message);
+                logger.Logger.LogError(ex, "Failed to execute ManageDeleteInternal for {Entity} with Key={Key}: {Message}", metadata.EntityType, key, ex.Message);
             }
         }
 
-        public static void ManageDelete<TKey>(IDiagnosticsLogger<DbLoggerCategory.Infrastructure> logger, IUpdateAdapter adapter, IEntityType entityType, IKey ikey, TKey key)
+        public static void ManageDelete<TKey>(IDiagnosticsLogger<DbLoggerCategory.Infrastructure> logger, IUpdateAdapter adapter, IValueContainerMetadata metadata, IKey ikey, TKey key)
             where TKey : notnull
         {
             if (key is not object?[] keyValues)
@@ -315,10 +315,10 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
             {
                 if (IsCriticalException(ex))
                 {
-                    logger.Logger.LogCritical(ex, "Failed to execute ManageDeleteInternal for {Entity} with Key={Key}: {Message}", entityType, key, ex.Message);
+                    logger.Logger.LogCritical(ex, "Failed to execute ManageDeleteInternal for {Entity} with Key={Key}: {Message}", metadata.EntityType, key, ex.Message);
                     throw;
                 }
-                logger.Logger.LogError(ex, "Failed to execute ManageDeleteInternal for {Entity} with Key={Key}: {Message}", entityType, key, ex.Message);
+                logger.Logger.LogError(ex, "Failed to execute ManageDeleteInternal for {Entity} with Key={Key}: {Message}", metadata.EntityType, key, ex.Message);
             }
         }
 
@@ -332,14 +332,14 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
             }
         }
 
-        public static void ManageFind(IDiagnosticsLogger<DbLoggerCategory.Infrastructure> logger, IUpdateAdapterFactory factory, IEntityType entityType, IKey key, object?[] keyValues, IDictionary<string, object?>? propertyValues, IDictionary<string, object?> complexPropertyValues)
+        public static void ManageFind(IDiagnosticsLogger<DbLoggerCategory.Infrastructure> logger, IUpdateAdapterFactory factory, IValueContainerMetadata metadata, IKey key, object?[] keyValues, IDictionary<string, object?>? propertyValues, IDictionary<string, object?> complexPropertyValues)
         {
             var adapter = factory.Create();
             IUpdateEntry? entry = adapter.TryGetEntry(key, keyValues);
             if (entry == null)
             {
                 logger.Logger.LogDebug("ManageFind: Record does not exist exists, add in state as Unchanged");
-                var entity2 = adapter.Model.FindEntityType(entityType.ClrType);
+                var entity2 = adapter.Model.FindEntityType(metadata.EntityType.ClrType);
                 // the key does not exist
                 var newEntry = adapter.CreateEntry(propertyValues!, entity2!);
                 var entityEntry = newEntry.ToEntityEntry();

--- a/src/net/KEFCore/Storage/Internal/KNetStreamsRetriever.cs
+++ b/src/net/KEFCore/Storage/Internal/KNetStreamsRetriever.cs
@@ -36,7 +36,7 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-public class KNetStreamsRetriever<TKey, TValue, TJVMKey, TJVMValue> : IKEFCoreStreamsRetriever<TKey>, IStreamsChangeManager
+public class KNetStreamsRetriever<TKey, TValue, TJVMKey, TJVMValue> : IKEFCoreStreamsRetriever<TKey, TValue>, IStreamsChangeManager
     where TKey : notnull
     where TValue : IValueContainer<TKey>
 {
@@ -190,27 +190,18 @@ public class KNetStreamsRetriever<TKey, TValue, TJVMKey, TJVMValue> : IKEFCoreSt
     }
 
     /// <inheritdoc/>
-    public bool TryGetProperties(TKey key, out IDictionary<string, object?> properties, out IDictionary<string, object?> complexProperties)
+    public bool TryGetProperties(TKey key, out TValue valueContainer)
     {
-        var v = GetTValue(key);
-        if (v == null)
-        {
-            properties = default!;
-            complexProperties = default!;
-            return false;
-        }
-
-        properties = v?.GetProperties(_metadata.EntityType)!;
-        complexProperties = v?.GetComplexProperties(_metadata.EntityType, _complexTypeConverterFactory)!;
-        return true;
+        valueContainer = GetTValue(key);
+        return valueContainer != null;
     }
 
     IEntityTypeProducer IStreamsChangeManager.Producer => _producer;
 
-    void IStreamsChangeManager.ManageChange(IDiagnosticsLogger<DbLoggerCategory.Infrastructure> infrastructureLogger, IValueGeneratorSelector valueGeneratorSelector, IUpdateAdapter adapter, IEntityType entityType, IKey primaryKey, object data)
+    void IStreamsChangeManager.ManageChange(IDiagnosticsLogger<DbLoggerCategory.Infrastructure> infrastructureLogger, IValueGeneratorSelector valueGeneratorSelector, IUpdateAdapter adapter, IValueContainerMetadata metadata, IKey primaryKey, object data)
     {
         var input = (Tuple<TKey, TValue>)data;
-        KEFCoreStateHelper.ManageAdded(infrastructureLogger, valueGeneratorSelector, _complexTypeConverterFactory, adapter, entityType, primaryKey, input.Item1, input.Item2);
+        KEFCoreStateHelper.ManageAdded(infrastructureLogger, valueGeneratorSelector, _complexTypeConverterFactory, adapter, metadata, primaryKey, input.Item1, input.Item2);
     }
 
     static IEnumerable<StoredEventChange> GetStoredData(KNetStreams streams, string storageId)

--- a/src/net/KEFCore/Storage/Internal/KafkaStreamsRetriever.cs
+++ b/src/net/KEFCore/Storage/Internal/KafkaStreamsRetriever.cs
@@ -40,7 +40,7 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-public class KafkaStreamsRetriever<TKey, TValue, K, V> : IKEFCoreStreamsRetriever<TKey>, IStreamsChangeManager
+public class KafkaStreamsRetriever<TKey, TValue, K, V> : IKEFCoreStreamsRetriever<TKey, TValue>, IStreamsChangeManager
     where TKey : notnull
     where TValue : IValueContainer<TKey>
 {
@@ -224,27 +224,24 @@ public class KafkaStreamsRetriever<TKey, TValue, K, V> : IKEFCoreStreamsRetrieve
         return true;
     }
     /// <inheritdoc/>
-    public bool TryGetProperties(TKey key, out IDictionary<string, object?> properties, out IDictionary<string, object?> complexProperties)
+    public bool TryGetProperties(TKey key, out TValue valueContainer)
     {
         var v = GetV(key);
         if (v == null)
         {
-            properties = default!;
-            complexProperties = default!;
+            valueContainer = default!;
             return false;
         }
-        var entityTypeData = _valueSerdes.DeserializeWithHeaders(null, null, v!);
-        properties = entityTypeData?.GetProperties(_metadata.EntityType)!;
-        complexProperties = entityTypeData?.GetComplexProperties(_metadata.EntityType, _complexTypeConverterFactory)!;
+        valueContainer = _valueSerdes.DeserializeWithHeaders(null, null, v!);
         return true;
     }
 
     IEntityTypeProducer IStreamsChangeManager.Producer => _producer;
 
-    void IStreamsChangeManager.ManageChange(IDiagnosticsLogger<DbLoggerCategory.Infrastructure> infrastructureLogger, IValueGeneratorSelector valueGeneratorSelector, IUpdateAdapter adapter, IEntityType entityType, IKey primaryKey, object data)
+    void IStreamsChangeManager.ManageChange(IDiagnosticsLogger<DbLoggerCategory.Infrastructure> infrastructureLogger, IValueGeneratorSelector valueGeneratorSelector, IUpdateAdapter adapter, IValueContainerMetadata metadata, IKey primaryKey, object data)
     {
         var input = (Tuple<TKey, TValue>)data;
-        KEFCoreStateHelper.ManageAdded(infrastructureLogger, valueGeneratorSelector, _complexTypeConverterFactory, adapter, entityType, primaryKey, input.Item1, input.Item2);
+        KEFCoreStateHelper.ManageAdded(infrastructureLogger, valueGeneratorSelector, _complexTypeConverterFactory, adapter, metadata, primaryKey, input.Item1, input.Item2);
     }
 
     static IEnumerable<StoredEventChange> GetStoredData(KafkaStreams streams, string storageId, object optional)

--- a/src/net/KEFCore/Storage/Internal/StreamsManager.cs
+++ b/src/net/KEFCore/Storage/Internal/StreamsManager.cs
@@ -24,6 +24,7 @@ using Java.Lang;
 using Java.Util;
 using MASES.EntityFrameworkCore.KNet.Extensions;
 using MASES.EntityFrameworkCore.KNet.Infrastructure.Internal;
+using MASES.EntityFrameworkCore.KNet.Serialization;
 using MASES.KNet.Streams;
 using Org.Apache.Kafka.Streams;
 using Org.Apache.Kafka.Streams.State;
@@ -60,7 +61,7 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
     internal interface IStreamsChangeManager
     {
         IEntityTypeProducer Producer { get; }
-        void ManageChange(IDiagnosticsLogger<DbLoggerCategory.Infrastructure> infrastructureLogger, IValueGeneratorSelector valueGeneratorSelector, IUpdateAdapter adapter, IEntityType entityType, IKey primaryKey, object data);
+        void ManageChange(IDiagnosticsLogger<DbLoggerCategory.Infrastructure> infrastructureLogger, IValueGeneratorSelector valueGeneratorSelector, IUpdateAdapter adapter, IValueContainerMetadata metadata, IKey primaryKey, object data);
     }
 
     #endregion
@@ -223,7 +224,7 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
                     {
                         IKEFCoreDatabase database = updater.Key.Database;
                         KEFCoreDatabaseLocalData localData = updater.Value;
-                        manager.ManageChange(database.InfrastructureLogger, selector, localData.UpdateAdapter, localData.EntityTypeForChanges, localData.PrimaryKeyForChanges, storedEvent.Data);
+                        manager.ManageChange(database.InfrastructureLogger, selector, localData.UpdateAdapter, localData.MetadataForChanges, localData.PrimaryKeyForChanges, storedEvent.Data);
                     }
                 }
             }
@@ -473,7 +474,7 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
                         {
                             IKEFCoreDatabase database = item.Key.Database;
                             KEFCoreDatabaseLocalData localData = item.Value;
-                            current.Manager.ManageChange(database.InfrastructureLogger, _kefcoreCluster.ValueGeneratorSelector, localData.UpdateAdapter, localData.EntityTypeForChanges, localData.PrimaryKeyForChanges, current.Data);
+                            current.Manager.ManageChange(database.InfrastructureLogger, _kefcoreCluster.ValueGeneratorSelector, localData.UpdateAdapter, localData.MetadataForChanges, localData.PrimaryKeyForChanges, current.Data);
                         }
                     }
                     while (!_freshDataFromCluster.IsEmpty);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The API of IValueContainer becomes more standard accepting only IValueContainerMetadata as input type. Since data comes from invariant serialization data, the internal implementation stores the converted data so subsequent requests returns immediately without reprocessing the content of IValueContainer.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
