### PR TITLE
Background-populate cache on partial enumeration

### DIFF
--- a/src/net/KEFCore/Storage/Internal/EntityTypeProducer.cs
+++ b/src/net/KEFCore/Storage/Internal/EntityTypeProducer.cs
@@ -556,17 +556,17 @@ public class EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContain
         if (keyValues == null) return null;
         if (_streamData != null)
         {
-            // construct key only if forward cache is warm — avoids non-trivial key allocation
-            TKey? key = _forwardCache.IsWarm
-                ? (TKey)_keyValueFactory.CreateFromKeyValues(keyValues)!
-                : default;
-
-            if (key != null && _forwardCache.TryGetValue(key, out var cached))
-                return cached;
-
-            // cache cold, disabled, or key not found — fall back to store
-            key ??= (TKey)_keyValueFactory.CreateFromKeyValues(keyValues)!;
-            return key != null && _streamData.TryGetValue(key, out var vb) ? vb : null;
+            if (_forwardCache.IsWarm)
+            {
+                // construct key only when cache is actually warm — avoids non-trivial allocation
+                TKey key = (TKey)_keyValueFactory.CreateFromKeyValues(keyValues)!;
+                if (_forwardCache.TryGetValue(key, out var cached)) return cached;
+                // cache warm but miss — fall through to store with the already-constructed key
+                return _streamData.TryGetValue(key, out var vbMiss) ? vbMiss : null;
+            }
+            // cache cold or disabled — go directly to store
+            TKey k = (TKey)_keyValueFactory.CreateFromKeyValues(keyValues)!;
+            return _streamData.TryGetValue(k, out var vb) ? vb : null;
         }
         else if (_knetCompactedReplicator != null)
         {
@@ -746,6 +746,4 @@ public class EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContain
             KEFCoreStateHelper.ManageDelete(database.InfrastructureLogger, localData.UpdateAdapter!, localData.MetadataForChanges!, localData.PrimaryKeyForChanges!, arg2.Key);
         }
     }
-
-
 }

--- a/src/net/KEFCore/Storage/Internal/KEFCoreCachedValueBufferStore.cs
+++ b/src/net/KEFCore/Storage/Internal/KEFCoreCachedValueBufferStore.cs
@@ -35,8 +35,11 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal;
 /// </para>
 /// <para>
 /// Partial enumerations (caller disposes the enumerator before <c>MoveNext</c> returns
-/// <see langword="false"/>) discard any accumulated data — the next call re-fetches from
-/// the upstream source.
+/// <see langword="false"/>) transparently hand off the upstream enumerator to a background
+/// task that completes the scan and commits the result to the cache. The caller sees no
+/// delay; the cache becomes warm once the background task finishes. A generation counter
+/// ensures that data accumulated before an <see cref="Invalidate"/> call is never committed
+/// after the invalidation.
 /// </para>
 /// <para>
 /// When <paramref name="ttl"/> is <see cref="TimeSpan.Zero"/> or negative, caching is
@@ -84,13 +87,17 @@ internal sealed class KEFCoreCachedValueBufferStore<TKey>
         private readonly KEFCoreCachedValueBufferStore<TKey> _store;
         private readonly IEnumerator<ValueBuffer> _inner;
         private readonly SortedList<TKey, ValueBuffer> _accumulator;
+        private readonly int _capturedGeneration;
         private bool _completed;
+        private bool _disposed;
 
         public PopulatingEnumerator(KEFCoreCachedValueBufferStore<TKey> store, IEnumerable<ValueBuffer> source)
         {
             _store = store;
             _inner = source.GetEnumerator();
             _accumulator = new SortedList<TKey, ValueBuffer>(store._comparer);
+            // capture generation before any MoveNext so we can detect intervening Invalidate()
+            lock (store._lock) _capturedGeneration = store._generation;
         }
 
         public ValueBuffer Current => _inner.Current;
@@ -114,24 +121,68 @@ internal sealed class KEFCoreCachedValueBufferStore<TKey>
 
         public void Dispose()
         {
-            _inner.Dispose();
+            if (_disposed) return;
+            _disposed = true;
+
             if (_completed)
             {
-                // full enumeration completed — commit to cache
-                lock (_store._lock)
+                // full enumeration — commit synchronously and dispose inner
+                _inner.Dispose();
+                TryCommit();
+                return;
+            }
+
+            // partial enumeration — hand off _inner to a background task that
+            // completes the scan and then commits. _inner must NOT be disposed here.
+            var inner = _inner;
+            var accumulator = _accumulator;
+            var store = _store;
+            var capturedGeneration = _capturedGeneration;
+
+            Task.Run(() =>
+            {
+                try
+                {
+                    while (inner.MoveNext())
+                    {
+                        var vb = inner.Current;
+                        var key = store.ExtractKey(vb);
+                        accumulator[key] = CopyValueBuffer(vb);
+                    }
+                    // full scan completed in background — try to commit
+                    lock (store._lock)
+                    {
+                        // only commit if no Invalidate() arrived since we started
+                        if (store._generation == capturedGeneration)
+                        {
+                            store._cache = accumulator;
+                            store._expiry = DateTime.UtcNow.Add(store._ttl);
+                        }
+                    }
+                }
+                catch
+                {
+                    // background population failure — cache stays cold, no action needed
+                }
+                finally
+                {
+                    inner.Dispose();
+                }
+            });
+        }
+
+        private void TryCommit()
+        {
+            lock (_store._lock)
+            {
+                if (_store._generation == _capturedGeneration)
                 {
                     _store._cache = _accumulator;
                     _store._expiry = DateTime.UtcNow.Add(_store._ttl);
                 }
             }
-            // partial enumeration — _accumulator is discarded, cache stays null/expired
         }
 
-        /// <summary>
-        /// Copies the underlying object array of a <see cref="ValueBuffer"/> so that
-        /// each cached entry has independent ownership and is not affected by the caller
-        /// reusing the upstream buffer.
-        /// </summary>
         private static ValueBuffer CopyValueBuffer(in ValueBuffer vb)
         {
             var arr = new object?[vb.Count];
@@ -150,6 +201,9 @@ internal sealed class KEFCoreCachedValueBufferStore<TKey>
     private SortedList<TKey, ValueBuffer>? _cache;
     private DateTime _expiry = DateTime.MinValue;
     private readonly object _lock = new();
+    // incremented by Invalidate() — background tasks compare against their captured value
+    // to avoid committing data that became stale after a write arrived mid-population
+    private int _generation = 0;
 
     // ── construction ──────────────────────────────────────────────────────────
     public KEFCoreCachedValueBufferStore(
@@ -181,6 +235,7 @@ internal sealed class KEFCoreCachedValueBufferStore<TKey>
         {
             _cache = null;
             _expiry = DateTime.MinValue;
+            _generation++;
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

When a caller disposes a partial enumerator, hand off the upstream enumerator to a background task that finishes scanning and commits the result to the cache so callers see no delay. Capture a generation counter at enumerator creation and increment it on Invalidate() to prevent stale background commits after a write; background tasks only commit if generations match. Refactor synchronous commit into TryCommit, add a disposed flag to guard Dispose, avoid disposing the upstream enumerator for partial enumerations (disposed in the background task), and preserve existing ValueBuffer copying logic.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
