### PR TITLE
Switch Register/Unregister of IStreamsManager from IEntityTypeProducer to IStreamsChangeManager with armonization of event source detection

### DIFF
--- a/src/net/KEFCore/Storage/Internal/EntityTypeProducer.cs
+++ b/src/net/KEFCore/Storage/Internal/EntityTypeProducer.cs
@@ -414,7 +414,7 @@ public class EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContain
         }
         else
         {
-            _streamsManager?.Register(this, database, _entityType);
+            _streamsManager?.Register(_streamData as IStreamsChangeManager, database, _entityType);
         }
     }
     /// <inheritdoc/>
@@ -429,7 +429,7 @@ public class EntityTypeProducer<TKey, TValueContainer, TJVMKey, TJVMValueContain
         }
         else if (_streamsManager != null)
         {
-            _streamsManager.Unregister(this, database);
+            _streamsManager.Unregister(_streamData as IStreamsChangeManager, database);
         }
     }
     /// <inheritdoc/>

--- a/src/net/KEFCore/Storage/Internal/IKEFCoreDatabase.cs
+++ b/src/net/KEFCore/Storage/Internal/IKEFCoreDatabase.cs
@@ -61,6 +61,14 @@ public interface IKEFCoreDatabase : IDatabase, IDisposable
     /// <param name="tables">The set of <see cref="IKEFCoreTable"/> to register</param>
     void RegisterTables(IEnumerable<IKEFCoreTable> tables);
     /// <summary>
+    /// Locks the instance during updates
+    /// </summary>
+    void Lock(CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Release the instance at the end of the update
+    /// </summary>
+    void Release();
+    /// <summary>
     /// Execute the <see cref="IDatabaseCreator.EnsureDeleted"/>
     /// </summary>
     bool EnsureDatabaseDeleted();
@@ -76,4 +84,6 @@ public interface IKEFCoreDatabase : IDatabase, IDisposable
     /// Verify if local instance is synchronized with the <see cref="Cluster"/>
     /// </summary>
     bool? EnsureDatabaseSynchronized(long timeout);
+
+
 }

--- a/src/net/KEFCore/Storage/Internal/KEFCoreCluster.cs
+++ b/src/net/KEFCore/Storage/Internal/KEFCoreCluster.cs
@@ -648,24 +648,34 @@ public class KEFCoreCluster(KEFCoreOptionsExtension options,
     {
         database.InfrastructureLogger.Logger.LogInformation("Invoking ExecuteTransaction for {number} entries", entries.Count);
 
-        Register(database);
+        int rowsAffected = 0;
 
-        using var ctSource = new CancellationTokenSource();
-        var tasks = ExecuteTransaction(database, entries, updateLogger, out var rowsAffected, ctSource.Token);
-        var result = Task.WhenAll(tasks);
-        result.Wait();
-        if (result.IsFaulted)
+        try
         {
-            updateLogger.ChangesSaved(entries, rowsAffected); // check entries not saved and update rowsAffected
+            database.Lock();
 
-            throw result.Exception;
+            Register(database);
+
+            using var ctSource = new CancellationTokenSource();
+            var tasks = ExecuteTransaction(database, entries, updateLogger, out rowsAffected, ctSource.Token);
+            var result = Task.WhenAll(tasks);
+            result.Wait();
+            if (result.IsFaulted)
+            {
+                updateLogger.ChangesSaved(entries, rowsAffected); // check entries not saved and update rowsAffected
+
+                throw result.Exception;
+            }
+
+            if (result.IsCompleted)
+            {
+                updateLogger.ChangesSaved(entries, rowsAffected);
+            }
         }
-
-        if (result.IsCompleted)
+        finally
         {
-            updateLogger.ChangesSaved(entries, rowsAffected);
+            database.Release();
         }
-
         return rowsAffected;
     }
 
@@ -673,18 +683,23 @@ public class KEFCoreCluster(KEFCoreOptionsExtension options,
     public async Task<int> ExecuteTransactionAsync(IKEFCoreDatabase database, System.Collections.Generic.IList<IUpdateEntry> entries, IDiagnosticsLogger<DbLoggerCategory.Update> updateLogger, CancellationToken cancellationToken = default)
     {
         database.InfrastructureLogger.Logger.LogInformation("Invoking ExecuteTransactionAsync for {number} entries", entries.Count);
-
-        Register(database);
-
-        var tasks = ExecuteTransaction(database, entries, updateLogger, out var rowsAffected, cancellationToken);
-
+        int rowsAffected = 0;
         try
         {
+            database.Lock(cancellationToken);
+            Register(database);
+
+            var tasks = ExecuteTransaction(database, entries, updateLogger, out rowsAffected, cancellationToken);
+
             await Task.WhenAll(tasks);
         }
         catch
         {
             updateLogger.ChangesSaved(entries, rowsAffected); // check for unsaved entries and update rowsAffected!
+        }
+        finally
+        {
+            database.Release();
         }
 
         return rowsAffected;

--- a/src/net/KEFCore/Storage/Internal/KEFCoreDatabase.cs
+++ b/src/net/KEFCore/Storage/Internal/KEFCoreDatabase.cs
@@ -37,6 +37,7 @@ public class KEFCoreDatabase : Database, IKEFCoreDatabase
     private readonly IDiagnosticsLogger<DbLoggerCategory.Update> _updateLogger;
     private readonly IDbContextTransactionManager _transactionManager;
     private readonly List<IKEFCoreTable> _tables;
+    private readonly SemaphoreSlim _semaphoreSlim = new(1);
     /// <summary>
     /// Default initializer
     /// </summary>
@@ -96,11 +97,22 @@ public class KEFCoreDatabase : Database, IKEFCoreDatabase
         }
     }
     /// <inheritdoc/>
+    public virtual void Lock(CancellationToken cancellationToken = default)
+    {
+        _semaphoreSlim.Wait(cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public virtual void Release()
+    {
+        _semaphoreSlim.Release();
+    }
+    /// <inheritdoc/>
     public override int SaveChanges(IList<IUpdateEntry> entries) => _cluster.ExecuteTransaction(this, entries, _updateLogger);
     /// <inheritdoc/>
     public override Task<int> SaveChangesAsync(
         IList<IUpdateEntry> entries,
-        CancellationToken cancellationToken = default) 
+        CancellationToken cancellationToken = default)
         => cancellationToken.IsCancellationRequested ? Task.FromCanceled<int>(cancellationToken)
                                                      : _cluster.ExecuteTransactionAsync(this, entries, _updateLogger, cancellationToken);
     /// <inheritdoc/>

--- a/src/net/KEFCore/Storage/Internal/KNetStreamsRetriever.cs
+++ b/src/net/KEFCore/Storage/Internal/KNetStreamsRetriever.cs
@@ -37,7 +37,7 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-public class KNetStreamsRetriever<TKey, TValue, TJVMKey, TJVMValue> : IKEFCoreStreamsRetriever<TKey, TValue>, IStreamsChangeManager
+sealed class KNetStreamsRetriever<TKey, TValue, TJVMKey, TJVMValue> : IKEFCoreStreamsRetriever<TKey, TValue>, IStreamsChangeManager
     where TKey : notnull
     where TValue : IValueContainer<TKey>
 {

--- a/src/net/KEFCore/Storage/Internal/KafkaStreamsRetriever.cs
+++ b/src/net/KEFCore/Storage/Internal/KafkaStreamsRetriever.cs
@@ -41,7 +41,7 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-public class KafkaStreamsRetriever<TKey, TValue, K, V> : IKEFCoreStreamsRetriever<TKey, TValue>, IStreamsChangeManager
+sealed class KafkaStreamsRetriever<TKey, TValue, K, V> : IKEFCoreStreamsRetriever<TKey, TValue>, IStreamsChangeManager
     where TKey : notnull
     where TValue : IValueContainer<TKey>
 {

--- a/src/net/KEFCore/Storage/Internal/StreamsManager.cs
+++ b/src/net/KEFCore/Storage/Internal/StreamsManager.cs
@@ -236,9 +236,17 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
                 {
                     foreach (var updater in updaters)
                     {
-                        IKEFCoreDatabase database = updater.Key.Database;
-                        KEFCoreDatabaseLocalData localData = updater.Value;
-                        manager.ManageChange(database.InfrastructureLogger, selector, localData.UpdateAdapter, localData.MetadataForChanges, localData.PrimaryKeyForChanges, storedEvent.Data);
+                        updater.Key.Database.Lock();
+                        try
+                        {
+                            IKEFCoreDatabase database = updater.Key.Database;
+                            KEFCoreDatabaseLocalData localData = updater.Value;
+                            manager.ManageChange(database.InfrastructureLogger, selector, localData.UpdateAdapter, localData.MetadataForChanges, localData.PrimaryKeyForChanges, storedEvent.Data);
+                        }
+                        finally
+                        {
+                            updater.Key.Database.Release();
+                        }
                     }
                 }
             }
@@ -483,12 +491,17 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
                     do
                     {
                         if (Interlocked.Read(ref canExecute) == 0) { System.Threading.Thread.Sleep(10); continue; }
-                        if (!_freshDataFromCluster.TryDequeue(out var current)) break;
+                        if (!_freshDataFromCluster.TryDequeue(out var current)) break;             
                         foreach (var item in _updaters.Where(item => item.Value.ManageEvents && item.Key.ChangeManager == current.Manager))
                         {
-                            IKEFCoreDatabase database = item.Key.Database;
-                            KEFCoreDatabaseLocalData localData = item.Value;
-                            current.Manager.ManageChange(database.InfrastructureLogger, _kefcoreCluster.ValueGeneratorSelector, localData.UpdateAdapter, localData.MetadataForChanges, localData.PrimaryKeyForChanges, current.Data);
+                            item.Key.Database.Lock();
+                            try
+                            {
+                                IKEFCoreDatabase database = item.Key.Database;
+                                KEFCoreDatabaseLocalData localData = item.Value;
+                                current.Manager.ManageChange(database.InfrastructureLogger, _kefcoreCluster.ValueGeneratorSelector, localData.UpdateAdapter, localData.MetadataForChanges, localData.PrimaryKeyForChanges, current.Data);
+                            }
+                            finally { item.Key.Database.Release(); }
                         }
                     }
                     while (!_freshDataFromCluster.IsEmpty);

--- a/src/net/KEFCore/Storage/Internal/StreamsManager.cs
+++ b/src/net/KEFCore/Storage/Internal/StreamsManager.cs
@@ -57,10 +57,24 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
     #endregion
 
     #region IStreamsChangeManager
-
-    interface IStreamsChangeManager
+    /// <summary>
+    /// Interface used to finalize event management
+    /// </summary>
+    public interface IStreamsChangeManager
     {
+        /// <summary>
+        /// The associated <see cref="IEntityTypeProducer"/>
+        /// </summary>
         IEntityTypeProducer Producer { get; }
+        /// <summary>
+        /// The method implement the change finalization
+        /// </summary>
+        /// <param name="infrastructureLogger"></param>
+        /// <param name="valueGeneratorSelector"></param>
+        /// <param name="adapter"></param>
+        /// <param name="metadata"></param>
+        /// <param name="primaryKey"></param>
+        /// <param name="data"></param>
         void ManageChange(IDiagnosticsLogger<DbLoggerCategory.Infrastructure> infrastructureLogger, IValueGeneratorSelector valueGeneratorSelector, IUpdateAdapter adapter, IValueContainerMetadata metadata, IKey primaryKey, object data);
     }
 
@@ -70,7 +84,7 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
     /// <summary>
     /// Central interface for stream management
     /// </summary>
-    interface IStreamsManager
+    public interface IStreamsManager
     {
         /// <summary>
         /// Register an instance of <see cref="IKEFCoreDatabase"/>

--- a/src/net/KEFCore/Storage/Internal/StreamsManager.cs
+++ b/src/net/KEFCore/Storage/Internal/StreamsManager.cs
@@ -29,8 +29,6 @@ using MASES.KNet.Streams;
 using Org.Apache.Kafka.Streams;
 using Org.Apache.Kafka.Streams.State;
 using System.Collections.Concurrent;
-using System.Runtime.CompilerServices;
-using static Org.Apache.Kafka.Streams.Errors.StreamsUncaughtExceptionHandler;
 
 namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
 {
@@ -398,10 +396,10 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
                     && streamsException.Message.Contains("TimestampExtractor", StringComparison.InvariantCultureIgnoreCase))
                 {
                     _kefcoreCluster.InfrastructureLogger.Logger?.LogCritical("StreamsUncaughtExceptionHandler received an exception of type {Exception} try with {Action}",
-                                                                           nameof(Org.Apache.Kafka.Streams.Errors.StreamsException), nameof(StreamThreadExceptionResponse.REPLACE_THREAD));
-                    return StreamThreadExceptionResponse.REPLACE_THREAD;
+                                                                           nameof(Org.Apache.Kafka.Streams.Errors.StreamsException), nameof(Org.Apache.Kafka.Streams.Errors.StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.REPLACE_THREAD));
+                    return Org.Apache.Kafka.Streams.Errors.StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.REPLACE_THREAD;
                 }
-                return StreamThreadExceptionResponse.SHUTDOWN_APPLICATION;
+                return Org.Apache.Kafka.Streams.Errors.StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.SHUTDOWN_APPLICATION;
             });
 
             _stateListener ??= new(this, (_This, newState, oldState) =>
@@ -795,7 +793,7 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
             }
             else throw new InvalidOperationException($"{entity} not found in managed entities.");
         }
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         private static bool EnsureSynchronized(StreamsAssociatedData storage, long timeout, Stopwatch watcher = null)
         {
             do

--- a/src/net/KEFCore/Storage/Internal/StreamsManager.cs
+++ b/src/net/KEFCore/Storage/Internal/StreamsManager.cs
@@ -58,7 +58,7 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
 
     #region IStreamsChangeManager
 
-    internal interface IStreamsChangeManager
+    interface IStreamsChangeManager
     {
         IEntityTypeProducer Producer { get; }
         void ManageChange(IDiagnosticsLogger<DbLoggerCategory.Infrastructure> infrastructureLogger, IValueGeneratorSelector valueGeneratorSelector, IUpdateAdapter adapter, IValueContainerMetadata metadata, IKey primaryKey, object data);
@@ -70,21 +70,21 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
     /// <summary>
     /// Central interface for stream management
     /// </summary>
-    public interface IStreamsManager
+    interface IStreamsManager
     {
         /// <summary>
         /// Register an instance of <see cref="IKEFCoreDatabase"/>
         /// </summary>
-        /// <param name="producer">The <see cref="IEntityTypeProducer"/> requesting the operation</param>
+        /// <param name="producer">The <see cref="IStreamsChangeManager"/> requesting the operation</param>
         /// <param name="database"><see cref="IKEFCoreDatabase"/></param>
         /// <param name="entity">Associated <see cref="IEntityType"/></param>
-        void Register(IEntityTypeProducer producer, IKEFCoreDatabase database, IEntityType entity);
+        void Register(IStreamsChangeManager producer, IKEFCoreDatabase database, IEntityType entity);
         /// <summary>
         /// Unregister an instance of <see cref="IKEFCoreDatabase"/>
         /// </summary>
-        /// <param name="producer">The <see cref="IEntityTypeProducer"/> requesting the operation</param>
+        /// <param name="producer">The <see cref="IStreamsChangeManager"/> requesting the operation</param>
         /// <param name="database"><see cref="IKEFCoreDatabase"/></param>
-        void Unregister(IEntityTypeProducer producer, IKEFCoreDatabase database);
+        void Unregister(IStreamsChangeManager producer, IKEFCoreDatabase database);
         /// <summary>
         /// Creates and start the topology
         /// </summary>
@@ -216,7 +216,7 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
             public void PushLocalStoredData(IValueGeneratorSelector selector, TStream streams, Func<TStream, string, object, IEnumerable<StoredEventChange>> factory)
             {
                 var manager = ChangeManager;
-                var updaters = StreamsManager._updaters.Where(item => item.Value.ManageEvents && item.Key.Producer == manager.Producer);
+                var updaters = StreamsManager._updaters.Where(item => item.Value.ManageEvents && item.Key.ChangeManager == manager);
 
                 foreach (var storedEvent in factory(streams, StorageId, Optional))
                 {
@@ -239,7 +239,7 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
 
         #region Read-only private
 
-        private readonly ConcurrentDictionary<(IEntityTypeProducer Producer, IKEFCoreDatabase Database), KEFCoreDatabaseLocalData> _updaters = new();
+        private readonly ConcurrentDictionary<(IStreamsChangeManager ChangeManager, IKEFCoreDatabase Database), KEFCoreDatabaseLocalData> _updaters = new();
         // enqueues changes from cluster when are send
         private readonly ConcurrentQueue<FreshEventChange> _freshDataFromCluster = new();
         // enqueues changes from cluster when are send
@@ -470,7 +470,7 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
                     {
                         if (Interlocked.Read(ref canExecute) == 0) { System.Threading.Thread.Sleep(10); continue; }
                         if (!_freshDataFromCluster.TryDequeue(out var current)) break;
-                        foreach (var item in _updaters.Where(item => item.Value.ManageEvents && item.Key.Producer == current.Manager))
+                        foreach (var item in _updaters.Where(item => item.Value.ManageEvents && item.Key.ChangeManager == current.Manager))
                         {
                             IKEFCoreDatabase database = item.Key.Database;
                             KEFCoreDatabaseLocalData localData = item.Value;
@@ -499,7 +499,7 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
             }
         }
 
-        public void Register(IEntityTypeProducer producer, IKEFCoreDatabase database, IEntityType entity)
+        public void Register(IStreamsChangeManager producer, IKEFCoreDatabase database, IEntityType entity)
         {
             if (!_updaters.TryAdd((producer, database), new KEFCoreDatabaseLocalData(database, entity)))
             {
@@ -507,7 +507,7 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
             }
         }
 
-        public void Unregister(IEntityTypeProducer producer, IKEFCoreDatabase database)
+        public void Unregister(IStreamsChangeManager producer, IKEFCoreDatabase database)
         {
             if (!_updaters.TryRemove((producer, database), out _))
             {

--- a/test/Common/ProgramConfig.cs
+++ b/test/Common/ProgramConfig.cs
@@ -210,14 +210,14 @@ namespace MASES.EntityFrameworkCore.KNet.Test.Common
             }
             else Config = new();
 
+#if DEBUG
+            Config.EnableIntermediateOutput = true;
+#endif
+
             foreach (var property in properties)
             {
                 property.Key.SetValue(Config, property.Value);
             }
-
-#if DEBUG
-            Config.EnableIntermediateOutput = true;
-#endif
 
             //if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.OSX)
             //    && Environment.GetEnvironmentVariable("GITHUB_ACTIONS") != null)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Replace IEntityTypeProducer usages with IStreamsChangeManager across stream management API and implementations. StreamsManager's Register/Unregister signatures and internal updaters dictionary now use IStreamsChangeManager, update lookups to compare ChangeManager, and reduce IStreamsManager visibility to internal. EntityTypeProducer now passes _streamData as IStreamsChangeManager when registering/unregistering. Also mark KNetStreamsRetriever and KafkaStreamsRetriever as sealed to tighten public surface. Changes unify the change-manager abstraction and narrow visibility of stream retrievers.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
