### PR TITLE
Improve resource disposal and event data types

### DIFF
--- a/src/net/KEFCore/Storage/Internal/KEFCoreClusterAdmin.cs
+++ b/src/net/KEFCore/Storage/Internal/KEFCoreClusterAdmin.cs
@@ -65,7 +65,7 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
                 {
                     if (ex.InnerException != null) throw ex.InnerException;
                     throw;
-                }         
+                }
                 _configuredAdminClient.TryAdd(key, adminClient);
             }
 
@@ -82,63 +82,53 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
 
         public string GetClusterId(IDiagnosticsLogger<DbLoggerCategory.Infrastructure> infrastructureLogger = null)
         {
-            DescribeClusterResult result = null;
-            KafkaFuture<Java.Lang.String> future = null;
             try
             {
-                result = _kafkaAdminClient?.DescribeCluster();
-                future = result?.ClusterId();
-                return future?.Get();
+                using var result = _kafkaAdminClient?.DescribeCluster();
+                using var future = result?.ClusterId();
+                using var res = future?.Get();
+                return res;
             }
             catch (ExecutionException ex)
             {
                 if (ex.InnerException != null) throw ex.InnerException;
                 throw;
             }
-            finally { future?.Dispose(); result?.Dispose(); }
         }
 
         public void CreateTopic(string topicName, int requestedPartitions, short requestedReplicationFactor, Map<Java.Lang.String, Java.Lang.String> options, IDiagnosticsLogger<DbLoggerCategory.Infrastructure> infrastructureLogger = null)
         {
-            Set<NewTopic> coll = default;
-            CreateTopicsResult result = default;
-            KafkaFuture<Java.Lang.Void> future = default;
-            NewTopic topic = default;
             try
             {
-                topic = new NewTopic((Java.Lang.String)topicName, requestedPartitions, requestedReplicationFactor);
-                topic.Configs(options);
-                coll = Collections.Singleton(topic);
-                result = _kafkaAdminClient?.CreateTopics(coll);
-                future = result?.All();
-                future?.Get();
+                using var topic1 = new NewTopic((Java.Lang.String)topicName, requestedPartitions, requestedReplicationFactor);
+                using var topic = topic1.Configs(options);
+                using var coll = Collections.Singleton(topic);
+                using var result = _kafkaAdminClient?.CreateTopics(coll);
+                using var future = result?.All();
+                using var res = future?.Get();
             }
             catch (ExecutionException ex)
             {
                 if (ex.InnerException != null) throw ex.InnerException;
                 throw;
             }
-            finally { topic?.Dispose(); future?.Dispose(); result?.Dispose(); coll?.Dispose(); }
         }
 
         public void DeleteTopics(Collection<Java.Lang.String> coll, IDiagnosticsLogger<DbLoggerCategory.Infrastructure> infrastructureLogger = null)
         {
             try
             {
-                DeleteTopicsResult result = default;
-                KafkaFuture<Java.Lang.Void> future = default;
                 try
                 {
-                    result = _kafkaAdminClient?.DeleteTopics(coll);
-                    future = result?.All();
-                    future?.Get();
+                    using var result = _kafkaAdminClient?.DeleteTopics(coll);
+                    using var future = result?.All();
+                    using var res = future?.Get();
                 }
                 catch (ExecutionException ex)
                 {
                     if (ex.InnerException != null) throw ex.InnerException;
                     else throw;
                 }
-                finally { future?.Dispose(); result?.Dispose(); }
             }
             catch (Org.Apache.Kafka.Common.Errors.UnknownTopicOrPartitionException utpe)
             {
@@ -151,38 +141,49 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
             try
             {
                 infrastructureLogger?.Logger.LogInformation("Trying to identify information of topics from the cluster.");
-                DescribeTopicsResult result = default;
-                KafkaFuture<Map<Java.Lang.String, TopicDescription>> future = default;
-                DescribeTopicsOptions describeTopicsOptions = new();
-                describeTopicsOptions.IncludeAuthorizedOperations(true);
+
                 try
                 {
-                    result = _kafkaAdminClient?.DescribeTopics(coll, describeTopicsOptions);
-                    future = result?.AllTopicNames();
-                    foreach (var item in future.Get().EntrySet())
+                    using DescribeTopicsOptions describeTopicsOptions = new();
+                    describeTopicsOptions.IncludeAuthorizedOperations(true);
+
+                    using var result = _kafkaAdminClient?.DescribeTopics(coll, describeTopicsOptions);
+                    using var future = result?.AllTopicNames();
+                    using var map = future.Get();
+                    using var entrySet = map.EntrySet();
+                    foreach (var item in entrySet)
                     {
-                        if (item.Value.IsInternal())
+                        using (item)
                         {
-                            infrastructureLogger?.Logger.LogDebug("Topic {Key} is internal", item.Key);
-                            continue;
-                        }
-                        var partitionsData = item.Value.Partitions();
-                        var numPartition = partitionsData.Size();
+                            using var key = item.Key;
+                            using var value = item.Value;
+                            if (value.IsInternal())
+                            {
+                                infrastructureLogger?.Logger.LogDebug("Topic {Key} is internal", key);
+                                continue;
+                            }
+                            using var partitionsData = value.Partitions();
+                            var numPartition = partitionsData.Size();
 
-                        bool write = false;
-                        bool read = false;
-
-                        foreach (var operation in item.Value.AuthorizedOperations())
-                        {
-                            if (operation == AclOperation.WRITE) write = true;
-                            if (operation == AclOperation.READ) read = true;
-                            infrastructureLogger?.Logger.LogDebug("Topic {Key} supports {Name}", item.Key, operation.Name());
+                            bool write = false;
+                            bool read = false;
+                            using var authOperations = value.AuthorizedOperations();
+                            foreach (var operation in authOperations)
+                            {
+                                using (operation)
+                                {
+                                    if (operation == AclOperation.WRITE) write = true;
+                                    if (operation == AclOperation.READ) read = true;
+                                    using var operationName = operation.Name();
+                                    infrastructureLogger?.Logger.LogDebug("Topic {Key} supports {Name}", key, operationName);
+                                }
+                            }
+                            if (readOnlyMode)
+                            {
+                                if (!read) throw new InvalidOperationException($"Topic {item.Key} shall support {AclOperation.READ}");
+                            }
+                            else if (!(read && write)) { throw new InvalidOperationException($"Topic {item.Key} shall support both {AclOperation.WRITE} and {AclOperation.READ}"); }
                         }
-                        if (readOnlyMode)
-                        {
-                            if (!read) throw new InvalidOperationException($"Topic {item.Key} shall support {AclOperation.READ}");
-                        }
-                        else if (!(read && write)) { throw new InvalidOperationException($"Topic {item.Key} shall support both {AclOperation.WRITE} and {AclOperation.READ}"); }
                     }
                 }
                 catch (ExecutionException ex)
@@ -194,7 +195,6 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
                     else if (ex.InnerException != null) throw ex.InnerException;
                     else throw;
                 }
-                finally { future?.Dispose(); result?.Dispose(); }
             }
             catch (UnknownTopicOrPartitionException ex)
             {
@@ -207,33 +207,49 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
             System.Collections.Generic.Dictionary<int, long> dictionary = new();
             try
             {
-                var coll = Collections.Singleton((Java.Lang.String)topicName);
-                DescribeTopicsResult describeTopicsResult = _kafkaAdminClient.DescribeTopics(coll);
+                using Java.Lang.String jTopic = topicName;
+                using var coll = Collections.Singleton(jTopic);
+                using DescribeTopicsResult describeTopicsResult = _kafkaAdminClient.DescribeTopics(coll);
                 using var future = describeTopicsResult.AllTopicNames();
-                var result = future.Get();
-                foreach (var item in result.EntrySet())
+                using var result = future.Get();
+                using var entrySet = result.EntrySet();
+                foreach (var item in entrySet)
                 {
-                    if (item.Key.Equals(topicName))
+                    using (item)
                     {
-                        HashMap<TopicPartition, OffsetSpec> hashMap = new();
-                        foreach (var partition in item.Value.Partitions())
+                        using var key = item.Key;
+                        using var value = item.Value;
+                        if (key.Equals(jTopic))
                         {
-                            var partitionIndex = partition.Partition();
-                            TopicPartition topicPartition = new(topicName, partitionIndex);
-                            hashMap.Put(topicPartition, OffsetSpec.Latest());
-                        }
-
-                        var listOffsetResult = _kafkaAdminClient.ListOffsets(hashMap);
-                        using var offsetResultFuture = listOffsetResult.All();
-                        var offsetResult = offsetResultFuture.Get();
-                        foreach (var offsetResultItem in offsetResult.EntrySet())
-                        {
-                            if (offsetResultItem.Key.Topic().Equals(topicName))
+                            using HashMap<TopicPartition, OffsetSpec> hashMap = new();
+                            using var partitions = value.Partitions();
+                            foreach (var partition in partitions)
                             {
-                                dictionary.Add(offsetResultItem.Key.Partition(), offsetResultItem.Value.Offset() - 1); // since latest means the latest used offset (a record in kafka) + 1, here we remove 1 to be in sync with received offset from kafka
+                                using (partition)
+                                {
+                                    var partitionIndex = partition.Partition();
+                                    using TopicPartition topicPartition = new(topicName, partitionIndex);
+                                    using var offsetSpec = OffsetSpec.Latest();
+                                    hashMap.Put(topicPartition, offsetSpec);
+                                }
                             }
+
+                            using var listOffsetResult = _kafkaAdminClient.ListOffsets(hashMap);
+                            using var offsetResultFuture = listOffsetResult.All();
+                            using var offsetResult = offsetResultFuture.Get();
+                            using var offsetResultEntrySet = offsetResult.EntrySet();
+                            foreach (var offsetResultItem in offsetResultEntrySet)
+                            {
+                                using var offsetResultItemKey = offsetResultItem.Key; 
+                                using var offsetResultItemValue = offsetResultItem.Value;
+                                using var offsetResultItemTopic = offsetResultItemKey.Topic();
+                                if (offsetResultItemTopic.Equals(jTopic))
+                                {
+                                    dictionary.Add(offsetResultItemKey.Partition(), offsetResultItemValue.Offset() - 1); // since latest means the latest used offset (a record in kafka) + 1, here we remove 1 to be in sync with received offset from kafka
+                                }
+                            }
+                            break;
                         }
-                        break;
                     }
                 }
                 return dictionary;

--- a/src/net/KEFCore/Storage/Internal/KEFCoreClusterAdmin.cs
+++ b/src/net/KEFCore/Storage/Internal/KEFCoreClusterAdmin.cs
@@ -162,8 +162,6 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
                                 infrastructureLogger?.Logger.LogDebug("Topic {Key} is internal", key);
                                 continue;
                             }
-                            using var partitionsData = value.Partitions();
-                            var numPartition = partitionsData.Size();
 
                             bool write = false;
                             bool read = false;
@@ -180,9 +178,9 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
                             }
                             if (readOnlyMode)
                             {
-                                if (!read) throw new InvalidOperationException($"Topic {item.Key} shall support {AclOperation.READ}");
+                                if (!read) throw new InvalidOperationException($"Topic {key} shall support {AclOperation.READ}");
                             }
-                            else if (!(read && write)) { throw new InvalidOperationException($"Topic {item.Key} shall support both {AclOperation.WRITE} and {AclOperation.READ}"); }
+                            else if (!(read && write)) { throw new InvalidOperationException($"Topic {key} shall support both {AclOperation.WRITE} and {AclOperation.READ}"); }
                         }
                     }
                 }

--- a/src/net/KEFCore/Storage/Internal/KNetStreamsRetriever.cs
+++ b/src/net/KEFCore/Storage/Internal/KNetStreamsRetriever.cs
@@ -51,7 +51,7 @@ public class KNetStreamsRetriever<TKey, TValue, TJVMKey, TJVMValue> : IKEFCoreSt
         {
             using (this.Record)
             {
-                _pushChanges.Invoke(new FreshEventChange(_manager, Record.Topic, Record.Partition, Record.Offset, new Tuple<TKey, TValue>(Record.Key, Record.Value)));
+                _pushChanges.Invoke(new FreshEventChange(_manager, Record.Topic, Record.Partition, Record.Offset, new FreshEventChangeExtraData<TKey, TValue>(Record.Key, Record.Value)));
                 return Record.DateTime;
             }
         }
@@ -204,8 +204,8 @@ public class KNetStreamsRetriever<TKey, TValue, TJVMKey, TJVMValue> : IKEFCoreSt
 
     void IStreamsChangeManager.ManageChange(IDiagnosticsLogger<DbLoggerCategory.Infrastructure> infrastructureLogger, IValueGeneratorSelector valueGeneratorSelector, IUpdateAdapter adapter, IValueContainerMetadata metadata, IKey primaryKey, object data)
     {
-        var input = (Tuple<TKey, TValue>)data;
-        KEFCoreStateHelper.ManageAdded(infrastructureLogger, valueGeneratorSelector, _complexTypeConverterFactory, adapter, metadata, primaryKey, input.Item1, input.Item2);
+        var input = (FreshEventChangeExtraData<TKey, TValue>)data;
+        KEFCoreStateHelper.ManageAdded(infrastructureLogger, valueGeneratorSelector, _complexTypeConverterFactory, adapter, metadata, primaryKey, input.Key, input.Value);
     }
 
     static IEnumerable<StoredEventChange> GetStoredData(KNetStreams streams, string storageId)

--- a/src/net/KEFCore/Storage/Internal/KNetStreamsRetriever.cs
+++ b/src/net/KEFCore/Storage/Internal/KNetStreamsRetriever.cs
@@ -217,7 +217,7 @@ public class KNetStreamsRetriever<TKey, TValue, TJVMKey, TJVMValue> : IKEFCoreSt
         {
             using (item)
             {
-                yield return new StoredEventChange(new Tuple<TKey, TValue>(item.Key, item.Value));
+                yield return new StoredEventChange(new FreshEventChangeExtraData<TKey, TValue>(item.Key, item.Value));
             }
         }
     }

--- a/src/net/KEFCore/Storage/Internal/KafkaStreamsRetriever.cs
+++ b/src/net/KEFCore/Storage/Internal/KafkaStreamsRetriever.cs
@@ -270,7 +270,7 @@ public class KafkaStreamsRetriever<TKey, TValue, K, V> : IKEFCoreStreamsRetrieve
             var value = kvSupport.Value;
             using var disposableKey = key as IDisposable;
             using var disposableValue = value as IDisposable;
-            yield return new StoredEventChange(new Tuple<TKey, TValue>(keySerdes.Deserialize(null, key), valueSerdes.Deserialize(null, value)));
+            yield return new StoredEventChange(new FreshEventChangeExtraData<TKey, TValue>(keySerdes.Deserialize(null, key), valueSerdes.Deserialize(null, value)));
         }
     }
 

--- a/src/net/KEFCore/Storage/Internal/KafkaStreamsRetriever.cs
+++ b/src/net/KEFCore/Storage/Internal/KafkaStreamsRetriever.cs
@@ -64,13 +64,17 @@ public class KafkaStreamsRetriever<TKey, TValue, K, V> : IKEFCoreStreamsRetrieve
         public override long Extract(ConsumerRecord<object, object> record, long timestamp)
         {
             using var record2 = record.CastTo<ConsumerRecord<K, V>>();
-            var topic = record2.Topic();
-            var headers = record2.Headers();
+            using var topic = record2.Topic();
+            using var headers = record2.Headers();
+            var jKey = record2.Key();
+            var jValue = record2.Value();
+            using var disposable1 = jKey as IDisposable;
+            using var disposable2 = jValue as IDisposable;
 
-            var key = _keySerdes.DeserializeWithHeaders(topic, headers, record2.Key());
-            var value = _valueSerdes.DeserializeWithHeaders(topic, headers, record2.Value());
+            var key = _keySerdes.DeserializeWithHeaders(topic, headers, jKey);
+            var value = _valueSerdes.DeserializeWithHeaders(topic, headers, jValue);
 
-            _pushChanges.Invoke(new FreshEventChange(_manager, topic, record.Partition(), record.Offset(), new Tuple<TKey, TValue>(key, value)));
+            _pushChanges.Invoke(new FreshEventChange(_manager, topic, record.Partition(), record.Offset(), new FreshEventChangeExtraData<TKey, TValue>(key, value)));
 
             return record.Timestamp();
         }
@@ -198,6 +202,7 @@ public class KafkaStreamsRetriever<TKey, TValue, K, V> : IKEFCoreStreamsRetrieve
         using ReadOnlyKeyValueStore<K, V>? keyValueStore = _streamsManager!.Streams?.Store(StoreQueryParameters<ReadOnlyKeyValueStore<K, V>>.FromNameAndType(_storageId, QueryableStoreTypes.KeyValueStore<K, V>()));
         if (keyValueStore == null) return default!;
         var k = _keySerdes.Serialize(null, key);
+        using var disposable = k as IDisposable;
         var v = keyValueStore.Get(k);
         return v;
     }
@@ -206,12 +211,14 @@ public class KafkaStreamsRetriever<TKey, TValue, K, V> : IKEFCoreStreamsRetrieve
     public bool Exist(TKey key)
     {
         var v = GetV(key);
+        using var disposable = v as IDisposable;
         return v != null;
     }
     /// <inheritdoc/>
     public bool TryGetValue(TKey key, out ValueBuffer valueBuffer)
     {
         var v = GetV(key);
+        using var disposable = v as IDisposable;
         if (v == null)
         {
             valueBuffer = ValueBuffer.Empty;
@@ -228,6 +235,7 @@ public class KafkaStreamsRetriever<TKey, TValue, K, V> : IKEFCoreStreamsRetrieve
     public bool TryGetProperties(TKey key, out TValue valueContainer)
     {
         var v = GetV(key);
+        using var disposable = v as IDisposable;
         if (v == null)
         {
             valueContainer = default!;
@@ -241,8 +249,8 @@ public class KafkaStreamsRetriever<TKey, TValue, K, V> : IKEFCoreStreamsRetrieve
 
     void IStreamsChangeManager.ManageChange(IDiagnosticsLogger<DbLoggerCategory.Infrastructure> infrastructureLogger, IValueGeneratorSelector valueGeneratorSelector, IUpdateAdapter adapter, IValueContainerMetadata metadata, IKey primaryKey, object data)
     {
-        var input = (Tuple<TKey, TValue>)data;
-        KEFCoreStateHelper.ManageAdded(infrastructureLogger, valueGeneratorSelector, _complexTypeConverterFactory, adapter, metadata, primaryKey, input.Item1, input.Item2);
+        var input = (FreshEventChangeExtraData<TKey, TValue>)data;
+        KEFCoreStateHelper.ManageAdded(infrastructureLogger, valueGeneratorSelector, _complexTypeConverterFactory, adapter, metadata, primaryKey, input.Key, input.Value);
     }
 
     static IEnumerable<StoredEventChange> GetStoredData(KafkaStreams streams, string storageId, object optional)
@@ -258,7 +266,11 @@ public class KafkaStreamsRetriever<TKey, TValue, K, V> : IKEFCoreStreamsRetrieve
         {
             using KeyValue<K, V> kv = iterator.Next();
             using var kvSupport = new MASES.KNet.Streams.KeyValueSupport<K, V>(kv);
-            yield return new StoredEventChange(new Tuple<TKey, TValue>(keySerdes.Deserialize(null, kvSupport.Key), valueSerdes.Deserialize(null, kvSupport.Value)));
+            var key = kvSupport.Key;
+            var value = kvSupport.Value;
+            using var disposableKey = key as IDisposable;
+            using var disposableValue = value as IDisposable;
+            yield return new StoredEventChange(new Tuple<TKey, TValue>(keySerdes.Deserialize(null, key), valueSerdes.Deserialize(null, value)));
         }
     }
 

--- a/src/net/KEFCore/Storage/Internal/StreamsManager.cs
+++ b/src/net/KEFCore/Storage/Internal/StreamsManager.cs
@@ -36,7 +36,15 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
 {
     #region FreshEventChange
 
-    internal readonly struct FreshEventChange(IStreamsChangeManager manager, string topic, int partition, long offset, object data)
+    readonly struct FreshEventChangeExtraData<TKey, TValue>(TKey key, TValue value)
+        where TKey : notnull
+        where TValue : IValueContainer<TKey>
+    {
+        public readonly TKey Key = key;
+        public readonly TValue Value = value;
+    }
+
+    readonly struct FreshEventChange(IStreamsChangeManager manager, string topic, int partition, long offset, object data)
     {
         public readonly IStreamsChangeManager Manager = manager;
         public readonly string Topic = topic;
@@ -49,7 +57,7 @@ namespace MASES.EntityFrameworkCore.KNet.Storage.Internal
 
     #region StoredEventChange
 
-    internal readonly struct StoredEventChange(object data)
+    readonly struct StoredEventChange(object data)
     {
         public readonly object Data = data;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Ensure proper disposal of Kafka/Java objects by replacing manual Dispose calls with using statements across KEFCoreClusterAdmin, KNet/KafkaStreamsRetriever and StreamsManager. Introduce FreshEventChangeExtraData<TKey,TValue> to carry key/value payloads instead of Tuple, and update change-management callsites accordingly. Also refine topic/authorization handling and offset listing to use scoped disposables and avoid leaking JVM resources. These changes reduce GC pressure and improve lifetime management of interop objects.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
