### PR TITLE
Add custom AvroValueContainer codec to reduce boxing

### DIFF
--- a/.github/workflows/build_common.yaml
+++ b/.github/workflows/build_common.yaml
@@ -293,7 +293,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        serialization: [ 'Json', 'Protobuf', 'Avro' ]
+        serialization: [ 'Json', 'Protobuf', 'Avro', 'AvroBinaryLegacy' ]
         os: ${{ fromJSON(needs.prepare_matrix_data.outputs.matrix_linux_os) }}
         framework: [ 'net8.0', 'net9.0', 'net10.0' ]
         jdk_vendor: ${{ fromJSON(needs.prepare_matrix_data.outputs.matrix_jdk_vendor) }}
@@ -416,7 +416,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        serialization: [ 'Json', 'Protobuf', 'Avro' ]
+        serialization: [ 'Json', 'Protobuf', 'Avro', 'AvroBinaryLegacy' ]
         os: ${{ fromJSON(needs.prepare_matrix_data.outputs.matrix_win_os) }}
         framework: [ 'net8.0', 'net9.0', 'net10.0' ]
         jdk_vendor: ${{ fromJSON(needs.prepare_matrix_data.outputs.matrix_jdk_vendor) }}
@@ -764,7 +764,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        serialization: [ 'Json', 'Protobuf', 'Avro' ]
+        serialization: [ 'Json', 'Protobuf', 'Avro', 'AvroBinaryLegacy' ]
         os: ${{ fromJSON(needs.prepare_matrix_data.outputs.matrix_mac_os) }}
         framework: [ 'net8.0', 'net9.0', 'net10.0' ]
         jdk_vendor: ${{ fromJSON(needs.prepare_matrix_data.outputs.matrix_jdk_vendor) }}

--- a/src/documentation/articles/gettingstarted.md
+++ b/src/documentation/articles/gettingstarted.md
@@ -105,7 +105,7 @@ KEFCore.CreateGlobalInstance();
 ```
 
 The previous command identify the JVM™ and start it, loads the needed libraries and setup the environment. Browsing the [repository](https://github.com/masesgroup/KEFCore) within the test folder there are some examples.
-KEFCore accepts many command-line switches to customize its behavior, the full list is available at [Command line switch](https://masesgroup.github.io/KNet/articles/commandlineswitch.html) of KNet.
+KEFCore accepts many command-line switches to customize its behavior, the full list is available at [Command line switch](https://knet.masesgroup.com/articles/commandlineswitch.html) of KNet.
 
 ### JVM™ identification
 

--- a/src/net/KEFCore.SerDes.Avro/AvroKEFCoreSerDes.cs
+++ b/src/net/KEFCore.SerDes.Avro/AvroKEFCoreSerDes.cs
@@ -16,8 +16,6 @@
 *  Refer to LICENSE for more information.
 */
 
-#define USE_CUSTOM_CODEC
-
 #nullable enable
 
 using Avro.IO;
@@ -31,7 +29,7 @@ using System.Text;
 namespace MASES.EntityFrameworkCore.KNet.Serialization.Avro;
 
 /// <summary>
-/// Avro base class to define extensions of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://masesgroup.github.io/KNet/articles/usageSerDes.html"/>
+/// Avro base class to define extensions of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://knet.masesgroup.com/articles/usageSerDes.html"/>
 /// </summary>
 public static class AvroKEFCoreSerDes
 {
@@ -55,6 +53,10 @@ public static class AvroKEFCoreSerDes
     }
 
     /// <summary>
+    /// Set to <see langword="true"/> to use legacy codec (generated)
+    /// </summary>
+    public static bool UseLegacyCodec = false;
+    /// <summary>
     /// Returns the default serializer <see cref="Type"/> for keys
     /// </summary>
     public static readonly Type DefaultKeySerialization = typeof(Key.Binary<>);
@@ -67,12 +69,12 @@ public static class AvroKEFCoreSerDes
     /// </summary>
     public static readonly Type DefaultValueContainer = typeof(AvroValueContainer<>);
     /// <summary>
-    /// Base class to define key extensions of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://masesgroup.github.io/KNet/articles/usageSerDes.html"/>
+    /// Base class to define key extensions of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://knet.masesgroup.com/articles/usageSerDes.html"/>
     /// </summary>
     public static class Key
     {
         /// <summary>
-        /// Base class to define key extensions of <see cref="ISerDesSelector{T}"/>, for example <see href="https://masesgroup.github.io/KNet/articles/usageSerDes.html"/>
+        /// Base class to define key extensions of <see cref="ISerDesSelector{T}"/>, for example <see href="https://knet.masesgroup.com/articles/usageSerDes.html"/>
         /// </summary>
         public class Binary<T> : ISerDesSelector<T>
         {
@@ -112,7 +114,7 @@ public static class AvroKEFCoreSerDes
             ISerDesBuffered<T> ISerDesSelector<T>.NewByteBufferSerDes() => NewByteBufferSerDes();
 
             /// <summary>
-            /// Avro Key Binary encoder extension of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://masesgroup.github.io/KNet/articles/usageSerDes.html"/> based on <see cref="byte"/> array
+            /// Avro Key Binary encoder extension of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://knet.masesgroup.com/articles/usageSerDes.html"/> based on <see cref="byte"/> array
             /// </summary>
             /// <typeparam name="TData"></typeparam>
             sealed class BinaryRaw<TData> : SerDesRaw<TData>
@@ -229,7 +231,7 @@ public static class AvroKEFCoreSerDes
             }
 
             /// <summary>
-            /// Avro Key Binary encoder extension of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://masesgroup.github.io/KNet/articles/usageSerDes.html"/> based on <see cref="ByteBuffer"/>
+            /// Avro Key Binary encoder extension of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://knet.masesgroup.com/articles/usageSerDes.html"/> based on <see cref="ByteBuffer"/>
             /// </summary>
             /// <typeparam name="TData"></typeparam>
             sealed class BinaryBuffered<TData> : SerDesBuffered<TData>
@@ -343,7 +345,7 @@ public static class AvroKEFCoreSerDes
         }
 
         /// <summary>
-        /// Base class to define key extensions of <see cref="ISerDesSelector{T}"/>, for example <see href="https://masesgroup.github.io/KNet/articles/usageSerDes.html"/>
+        /// Base class to define key extensions of <see cref="ISerDesSelector{T}"/>, for example <see href="https://knet.masesgroup.com/articles/usageSerDes.html"/>
         /// </summary>
         public class Json<T> : ISerDesSelector<T>
         {
@@ -383,7 +385,7 @@ public static class AvroKEFCoreSerDes
             ISerDesBuffered<T> ISerDesSelector<T>.NewByteBufferSerDes() => NewByteBufferSerDes();
 
             /// <summary>
-            /// Avro Key Json encoder extension of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://masesgroup.github.io/KNet/articles/usageSerDes.html"/> based on <see cref="byte"/> array
+            /// Avro Key Json encoder extension of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://knet.masesgroup.com/articles/usageSerDes.html"/> based on <see cref="byte"/> array
             /// </summary>
             /// <typeparam name="TData"></typeparam>
             sealed class JsonRaw<TData> : SerDesRaw<TData>
@@ -490,7 +492,7 @@ public static class AvroKEFCoreSerDes
             }
 
             /// <summary>
-            /// Avro Key Json encoder extension of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://masesgroup.github.io/KNet/articles/usageSerDes.html"/> based on <see cref="ByteBuffer"/>
+            /// Avro Key Json encoder extension of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://knet.masesgroup.com/articles/usageSerDes.html"/> based on <see cref="ByteBuffer"/>
             /// </summary>
             /// <typeparam name="TData"></typeparam>
             sealed class JsonBuffered<TData> : SerDesBuffered<TData>
@@ -599,12 +601,12 @@ public static class AvroKEFCoreSerDes
     }
 
     /// <summary>
-    /// Base class to define ValueContainer extensions of <see cref="ISerDesSelector{T}"/>, for example <see href="https://masesgroup.github.io/KNet/articles/usageSerDes.html"/>
+    /// Base class to define ValueContainer extensions of <see cref="ISerDesSelector{T}"/>, for example <see href="https://knet.masesgroup.com/articles/usageSerDes.html"/>
     /// </summary>
     public static class ValueContainer
     {
         /// <summary>
-        /// Base class to define key extensions of <see cref="ISerDesSelector{T}"/>, for example <see href="https://masesgroup.github.io/KNet/articles/usageSerDes.html"/>
+        /// Base class to define key extensions of <see cref="ISerDesSelector{T}"/>, for example <see href="https://knet.masesgroup.com/articles/usageSerDes.html"/>
         /// </summary>
         public class Binary<T> : ISerDesSelector<T> where T: AvroValueContainer
         {
@@ -644,7 +646,7 @@ public static class AvroKEFCoreSerDes
             ISerDesBuffered<T> ISerDesSelector<T>.NewByteBufferSerDes() => NewByteBufferSerDes();
 
             /// <summary>
-            /// Avro ValueContainer Binary encoder extension of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://masesgroup.github.io/KNet/articles/usageSerDes.html"/> based on <see cref="byte"/> array
+            /// Avro ValueContainer Binary encoder extension of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://knet.masesgroup.com/articles/usageSerDes.html"/> based on <see cref="byte"/> array
             /// </summary>
             /// <typeparam name="TData"></typeparam>
             sealed class BinaryRaw<TData> : SerDesRaw<TData> where TData : AvroValueContainer
@@ -697,11 +699,14 @@ public static class AvroKEFCoreSerDes
 
                     using MemoryStream memStream = RecyclableMemoryStreamSupport.Rent();
                     BinaryEncoder encoder = new(memStream);
-#if USE_CUSTOM_CODEC
-                    AvroValueContainerCodec.Write(data, encoder);
-#else
-                    SpecificWriter.Write(data, encoder);
-#endif
+                    if (!UseLegacyCodec)
+                    {
+                        AvroValueContainerCodec.Write(data, encoder);
+                    }
+                    else
+                    {
+                        SpecificWriter.Write(data, encoder);
+                    }
                     return memStream.ToArray();
                 }
                 /// <inheritdoc cref="SerDes{TData, TJVM}.SerializeWithHeaders(Java.Lang.String, Headers, TData)"/>
@@ -714,11 +719,14 @@ public static class AvroKEFCoreSerDes
 
                     using MemoryStream memStream = RecyclableMemoryStreamSupport.Rent();
                     BinaryEncoder encoder = new(memStream);
-#if USE_CUSTOM_CODEC
-                    AvroValueContainerCodec.Write(data, encoder);
-#else
-                    SpecificWriter.Write(data, encoder);
-#endif
+                    if (!UseLegacyCodec)
+                    {
+                        AvroValueContainerCodec.Write(data, encoder);
+                    }
+                    else
+                    {
+                        SpecificWriter.Write(data, encoder);
+                    }
                     return memStream.ToArray();
                 }
                 /// <inheritdoc cref="SerDes{TData, TJVM}.Deserialize(string, TJVM)"/>
@@ -738,13 +746,15 @@ public static class AvroKEFCoreSerDes
 
                     using MemoryStream memStream = new(data);
                     BinaryDecoder decoder = new(memStream);
-#if USE_CUSTOM_CODEC
-                    TData t = AvroValueContainerCodec.Read(decoder, static () => ValueContainerFactory<TData>.Create());
-#else
-                    TData t = ValueContainerFactory<TData>.Create();
-                    t = SpecificReader.Read(t!, decoder);
-#endif
-                    return t;
+                    if (!UseLegacyCodec)
+                    {
+                        return AvroValueContainerCodec.Read(decoder, static () => ValueContainerFactory<TData>.Create());
+                    }
+                    else
+                    {
+                        TData t = ValueContainerFactory<TData>.Create();
+                        return SpecificReader.Read(t!, decoder);
+                    }
                 }
                 /// <inheritdoc cref="SerDes{TData, TJVM}.DeserializeWithHeaders(Java.Lang.String, Headers, TJVM)"/>
                 public override TData DeserializeWithHeaders(Java.Lang.String topic, Headers headers, byte[] data)
@@ -753,18 +763,20 @@ public static class AvroKEFCoreSerDes
 
                     using MemoryStream memStream = new(data);
                     BinaryDecoder decoder = new(memStream);
-#if USE_CUSTOM_CODEC
-                    TData t = AvroValueContainerCodec.Read(decoder, static () => ValueContainerFactory<TData>.Create());
-#else
-                    TData t = ValueContainerFactory<TData>.Create();
-                    t = SpecificReader.Read(t!, decoder);
-#endif
-                    return t;
+                    if (!UseLegacyCodec)
+                    {
+                        return AvroValueContainerCodec.Read(decoder, static () => ValueContainerFactory<TData>.Create());
+                    }
+                    else
+                    {
+                        TData t = ValueContainerFactory<TData>.Create();
+                        return SpecificReader.Read(t!, decoder);
+                    }
                 }
             }
 
             /// <summary>
-            /// Avro ValueContainer Binary encoder extension of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://masesgroup.github.io/KNet/articles/usageSerDes.html"/> based on <see cref="ByteBuffer"/>
+            /// Avro ValueContainer Binary encoder extension of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://knet.masesgroup.com/articles/usageSerDes.html"/> based on <see cref="ByteBuffer"/>
             /// </summary>
             /// <typeparam name="TData"></typeparam>
             sealed class BinaryBuffered<TData> : SerDesBuffered<TData> where TData : AvroValueContainer
@@ -817,11 +829,14 @@ public static class AvroKEFCoreSerDes
 
                     var memStream = ByteBuffer.Rent();
                     BinaryEncoder encoder = new(memStream);
-#if USE_CUSTOM_CODEC
-                    AvroValueContainerCodec.Write(data, encoder);
-#else
-                    SpecificWriter.Write(data, encoder);
-#endif
+                    if (!UseLegacyCodec)
+                    {
+                        AvroValueContainerCodec.Write(data, encoder);
+                    }
+                    else
+                    {
+                        SpecificWriter.Write(data, encoder);
+                    }
                     return ByteBuffer.From(memStream);
                 }
                 /// <inheritdoc cref="SerDes{TData, TJVM}.SerializeWithHeaders(Java.Lang.String, Headers, TData)"/>
@@ -834,11 +849,14 @@ public static class AvroKEFCoreSerDes
 
                     var memStream = ByteBuffer.Rent();
                     BinaryEncoder encoder = new(memStream);
-#if USE_CUSTOM_CODEC
-                    AvroValueContainerCodec.Write(data, encoder);
-#else
-                    SpecificWriter.Write(data, encoder);
-#endif
+                    if (!UseLegacyCodec)
+                    {
+                        AvroValueContainerCodec.Write(data, encoder);
+                    }
+                    else
+                    {
+                        SpecificWriter.Write(data, encoder);
+                    }
                     return ByteBuffer.From(memStream);
                 }
                 /// <inheritdoc cref="SerDes{TData, TJVM}.Deserialize(string, TJVM)"/>
@@ -857,13 +875,15 @@ public static class AvroKEFCoreSerDes
                     if (data == null) return default!;
                     using var stream = data.ToStream();
                     BinaryDecoder decoder = new(stream);
-#if USE_CUSTOM_CODEC
-                    TData t = AvroValueContainerCodec.Read(decoder, static () => ValueContainerFactory<TData>.Create());
-#else
-                    TData t = ValueContainerFactory<TData>.Create();
-                    t = SpecificReader.Read(t!, decoder);
-#endif
-                    return t;
+                    if (!UseLegacyCodec)
+                    {
+                        return AvroValueContainerCodec.Read(decoder, static () => ValueContainerFactory<TData>.Create());
+                    }
+                    else
+                    {
+                        TData t = ValueContainerFactory<TData>.Create();
+                        return SpecificReader.Read(t!, decoder);
+                    }
                 }
                 /// <inheritdoc cref="SerDes{TData, TJVM}.DeserializeWithHeaders(Java.Lang.String, Headers, TJVM)"/>
                 public override TData DeserializeWithHeaders(Java.Lang.String topic, Headers headers, ByteBuffer data)
@@ -871,19 +891,21 @@ public static class AvroKEFCoreSerDes
                     if (data == null) return default!;
                     using var stream = data.ToStream();
                     BinaryDecoder decoder = new(stream);
-#if USE_CUSTOM_CODEC
-                    TData t = AvroValueContainerCodec.Read(decoder, static () => ValueContainerFactory<TData>.Create());
-#else
-                    TData t = ValueContainerFactory<TData>.Create();
-                    t = SpecificReader.Read(t!, decoder);
-#endif
-                    return t;
+                    if (!UseLegacyCodec)
+                    {
+                        return AvroValueContainerCodec.Read(decoder, static () => ValueContainerFactory<TData>.Create());
+                    }
+                    else
+                    {
+                        TData t = ValueContainerFactory<TData>.Create();
+                        return SpecificReader.Read(t!, decoder);
+                    }
                 }
             }
         }
 
         /// <summary>
-        /// Base class to define key extensions of <see cref="ISerDesSelector{T}"/>, for example <see href="https://masesgroup.github.io/KNet/articles/usageSerDes.html"/>
+        /// Base class to define key extensions of <see cref="ISerDesSelector{T}"/>, for example <see href="https://knet.masesgroup.com/articles/usageSerDes.html"/>
         /// </summary>
         public class Json<T> : ISerDesSelector<T>
         {
@@ -923,7 +945,7 @@ public static class AvroKEFCoreSerDes
             ISerDesBuffered<T> ISerDesSelector<T>.NewByteBufferSerDes() => NewByteBufferSerDes();
 
             /// <summary>
-            /// Avro ValueContainer Json encoder extension of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://masesgroup.github.io/KNet/articles/usageSerDes.html"/> based on <see cref="byte"/> array
+            /// Avro ValueContainer Json encoder extension of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://knet.masesgroup.com/articles/usageSerDes.html"/> based on <see cref="byte"/> array
             /// </summary>
             /// <typeparam name="TData"></typeparam>
             sealed class JsonRaw<TData> : SerDesRaw<TData>
@@ -1029,7 +1051,7 @@ public static class AvroKEFCoreSerDes
             }
 
             /// <summary>
-            /// Avro ValueContainer Json encoder extension of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://masesgroup.github.io/KNet/articles/usageSerDes.html"/> based on <see cref="ByteBuffer"/>
+            /// Avro ValueContainer Json encoder extension of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://knet.masesgroup.com/articles/usageSerDes.html"/> based on <see cref="ByteBuffer"/>
             /// </summary>
             /// <typeparam name="TData"></typeparam>
             sealed class JsonBuffered<TData> : SerDesBuffered<TData>

--- a/src/net/KEFCore.SerDes.Avro/AvroKEFCoreSerDes.cs
+++ b/src/net/KEFCore.SerDes.Avro/AvroKEFCoreSerDes.cs
@@ -16,6 +16,8 @@
 *  Refer to LICENSE for more information.
 */
 
+#define USE_CUSTOM_CODEC
+
 #nullable enable
 
 using Avro.IO;
@@ -604,7 +606,7 @@ public static class AvroKEFCoreSerDes
         /// <summary>
         /// Base class to define key extensions of <see cref="ISerDesSelector{T}"/>, for example <see href="https://masesgroup.github.io/KNet/articles/usageSerDes.html"/>
         /// </summary>
-        public class Binary<T> : ISerDesSelector<T>
+        public class Binary<T> : ISerDesSelector<T> where T: AvroValueContainer
         {
             /// <summary>
             /// Returns a new instance of <see cref="Binary{T}"/>
@@ -645,7 +647,7 @@ public static class AvroKEFCoreSerDes
             /// Avro ValueContainer Binary encoder extension of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://masesgroup.github.io/KNet/articles/usageSerDes.html"/> based on <see cref="byte"/> array
             /// </summary>
             /// <typeparam name="TData"></typeparam>
-            sealed class BinaryRaw<TData> : SerDesRaw<TData>
+            sealed class BinaryRaw<TData> : SerDesRaw<TData> where TData : AvroValueContainer
             {
                 readonly byte[] valueContainerSerDesName;
                 readonly byte[] valueContainerName = null!;
@@ -695,7 +697,11 @@ public static class AvroKEFCoreSerDes
 
                     using MemoryStream memStream = RecyclableMemoryStreamSupport.Rent();
                     BinaryEncoder encoder = new(memStream);
+#if USE_CUSTOM_CODEC
+                    AvroValueContainerCodec.Write(data, encoder);
+#else
                     SpecificWriter.Write(data, encoder);
+#endif
                     return memStream.ToArray();
                 }
                 /// <inheritdoc cref="SerDes{TData, TJVM}.SerializeWithHeaders(Java.Lang.String, Headers, TData)"/>
@@ -708,7 +714,11 @@ public static class AvroKEFCoreSerDes
 
                     using MemoryStream memStream = RecyclableMemoryStreamSupport.Rent();
                     BinaryEncoder encoder = new(memStream);
+#if USE_CUSTOM_CODEC
+                    AvroValueContainerCodec.Write(data, encoder);
+#else
                     SpecificWriter.Write(data, encoder);
+#endif
                     return memStream.ToArray();
                 }
                 /// <inheritdoc cref="SerDes{TData, TJVM}.Deserialize(string, TJVM)"/>
@@ -728,8 +738,12 @@ public static class AvroKEFCoreSerDes
 
                     using MemoryStream memStream = new(data);
                     BinaryDecoder decoder = new(memStream);
+#if USE_CUSTOM_CODEC
+                    TData t = AvroValueContainerCodec.Read(decoder, static () => ValueContainerFactory<TData>.Create());
+#else
                     TData t = ValueContainerFactory<TData>.Create();
                     t = SpecificReader.Read(t!, decoder);
+#endif
                     return t;
                 }
                 /// <inheritdoc cref="SerDes{TData, TJVM}.DeserializeWithHeaders(Java.Lang.String, Headers, TJVM)"/>
@@ -739,8 +753,12 @@ public static class AvroKEFCoreSerDes
 
                     using MemoryStream memStream = new(data);
                     BinaryDecoder decoder = new(memStream);
+#if USE_CUSTOM_CODEC
+                    TData t = AvroValueContainerCodec.Read(decoder, static () => ValueContainerFactory<TData>.Create());
+#else
                     TData t = ValueContainerFactory<TData>.Create();
                     t = SpecificReader.Read(t!, decoder);
+#endif
                     return t;
                 }
             }
@@ -749,7 +767,7 @@ public static class AvroKEFCoreSerDes
             /// Avro ValueContainer Binary encoder extension of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://masesgroup.github.io/KNet/articles/usageSerDes.html"/> based on <see cref="ByteBuffer"/>
             /// </summary>
             /// <typeparam name="TData"></typeparam>
-            sealed class BinaryBuffered<TData> : SerDesBuffered<TData>
+            sealed class BinaryBuffered<TData> : SerDesBuffered<TData> where TData : AvroValueContainer
             {
                 readonly byte[] valueContainerSerDesName;
                 readonly byte[] valueContainerName = null!;
@@ -799,7 +817,11 @@ public static class AvroKEFCoreSerDes
 
                     var memStream = ByteBuffer.Rent();
                     BinaryEncoder encoder = new(memStream);
+#if USE_CUSTOM_CODEC
+                    AvroValueContainerCodec.Write(data, encoder);
+#else
                     SpecificWriter.Write(data, encoder);
+#endif
                     return ByteBuffer.From(memStream);
                 }
                 /// <inheritdoc cref="SerDes{TData, TJVM}.SerializeWithHeaders(Java.Lang.String, Headers, TData)"/>
@@ -812,7 +834,11 @@ public static class AvroKEFCoreSerDes
 
                     var memStream = ByteBuffer.Rent();
                     BinaryEncoder encoder = new(memStream);
+#if USE_CUSTOM_CODEC
+                    AvroValueContainerCodec.Write(data, encoder);
+#else
                     SpecificWriter.Write(data, encoder);
+#endif
                     return ByteBuffer.From(memStream);
                 }
                 /// <inheritdoc cref="SerDes{TData, TJVM}.Deserialize(string, TJVM)"/>
@@ -831,8 +857,12 @@ public static class AvroKEFCoreSerDes
                     if (data == null) return default!;
                     using var stream = data.ToStream();
                     BinaryDecoder decoder = new(stream);
+#if USE_CUSTOM_CODEC
+                    TData t = AvroValueContainerCodec.Read(decoder, static () => ValueContainerFactory<TData>.Create());
+#else
                     TData t = ValueContainerFactory<TData>.Create();
                     t = SpecificReader.Read(t!, decoder);
+#endif
                     return t;
                 }
                 /// <inheritdoc cref="SerDes{TData, TJVM}.DeserializeWithHeaders(Java.Lang.String, Headers, TJVM)"/>
@@ -841,8 +871,12 @@ public static class AvroKEFCoreSerDes
                     if (data == null) return default!;
                     using var stream = data.ToStream();
                     BinaryDecoder decoder = new(stream);
+#if USE_CUSTOM_CODEC
+                    TData t = AvroValueContainerCodec.Read(decoder, static () => ValueContainerFactory<TData>.Create());
+#else
                     TData t = ValueContainerFactory<TData>.Create();
                     t = SpecificReader.Read(t!, decoder);
+#endif
                     return t;
                 }
             }

--- a/src/net/KEFCore.SerDes.Avro/AvroValueContainerCodec.cs
+++ b/src/net/KEFCore.SerDes.Avro/AvroValueContainerCodec.cs
@@ -1,0 +1,233 @@
+﻿/*
+*  Copyright (c) 2022-2026 MASES s.r.l.
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*  Refer to LICENSE for more information.
+*/
+
+using global::Avro.IO;
+using global::MASES.EntityFrameworkCore.KNet.Serialization.Avro.Storage;
+
+// Direct codec for AvroValueContainer, replacing SpecificDefaultWriter/SpecificDefaultReader.
+//
+// Drop-in replacement points in AvroKEFCoreSerDes.cs (both BinaryRaw<TData> and
+// BinaryBuffered<TData> nested classes, around lines ~652-757 and the analogous
+// AvroKeyContainer blocks if the same approach is applied there too):
+//
+//   BEFORE:
+//     SpecificWriter.Write(data, encoder);
+//     ...
+//     t = SpecificReader.Read(t!, decoder);
+//
+//   AFTER:
+//     AvroValueContainerCodec.Write(data, encoder);
+//     ...
+//     t = AvroValueContainerCodec.Read(decoder, () => ValueContainerFactory<TData>.Create());
+//
+// Union branch order for "Value" confirmed from AvroValueContainer.avsc:
+//   0: null, 1: boolean, 2: int, 3: long, 4: float, 5: double, 6: string, 7: bytes
+
+namespace MASES.EntityFrameworkCore.KNet.Serialization.Avro.Storage
+{
+    /// <summary>
+    /// Hand-written direct codec for <see cref="AvroValueContainer"/> and its nested
+    /// <see cref="PropertyDataRecord"/> entries. Bypasses ISpecificRecord.Get(int)/Put(int, object),
+    /// avoiding one boxing allocation per scalar field per property per entity.
+    /// </summary>
+    public static class AvroValueContainerCodec
+    {
+        // --- WRITE -----------------------------------------------------------
+
+        public static void Write(AvroValueContainer container, Encoder encoder)
+        {
+            encoder.WriteString(container.EntityName);
+            encoder.WriteString(container.ClrType);
+
+            var data = container.Data;
+            int count = data.Count;
+            // Avro array encoding: a sequence of blocks, each with a non-zero item count
+            // followed by that many items, terminated by a zero-count block.
+            encoder.WriteArrayStart();
+            encoder.SetItemCount(count);
+            for (int i = 0; i < count; i++)
+            {
+                encoder.StartItem();
+                WriteProperty(data[i], encoder);
+            }
+            encoder.WriteArrayEnd();
+        }
+
+        private static void WriteProperty(PropertyDataRecord record, Encoder encoder)
+        {
+            // optional int -> union [null, int]
+            if (record.PropertyIndex.HasValue)
+            {
+                encoder.WriteUnionIndex(1);
+                encoder.WriteInt(record.PropertyIndex.Value);
+            }
+            else
+            {
+                encoder.WriteUnionIndex(0);
+                encoder.WriteNull();
+            }
+
+            encoder.WriteString(record.PropertyName);
+
+            // plain int / bool — no union, no boxing already in the generated class,
+            // but writing them directly here avoids the Get(int)/Put(int,object) round trip too.
+            encoder.WriteInt(record.ManagedType);
+            encoder.WriteBoolean(record.SupportNull);
+
+            // optional string -> union [null, string]
+            if (record.ClrType != null)
+            {
+                encoder.WriteUnionIndex(1);
+                encoder.WriteString(record.ClrType);
+            }
+            else
+            {
+                encoder.WriteUnionIndex(0);
+                encoder.WriteNull();
+            }
+
+            // Value union: null, boolean, int, long, float, double, string, bytes
+            WriteValueUnion(record.Value, encoder);
+        }
+
+        private static void WriteValueUnion(object value, Encoder encoder)
+        {
+            switch (value)
+            {
+                case null:
+                    encoder.WriteUnionIndex(0);
+                    encoder.WriteNull();
+                    break;
+                case bool b:
+                    encoder.WriteUnionIndex(1);
+                    encoder.WriteBoolean(b);
+                    break;
+                case int i:
+                    encoder.WriteUnionIndex(2);
+                    encoder.WriteInt(i);
+                    break;
+                case long l:
+                    encoder.WriteUnionIndex(3);
+                    encoder.WriteLong(l);
+                    break;
+                case float f:
+                    encoder.WriteUnionIndex(4);
+                    encoder.WriteFloat(f);
+                    break;
+                case double d:
+                    encoder.WriteUnionIndex(5);
+                    encoder.WriteDouble(d);
+                    break;
+                case string s:
+                    encoder.WriteUnionIndex(6);
+                    encoder.WriteString(s);
+                    break;
+                case byte[] bytes:
+                    encoder.WriteUnionIndex(7);
+                    encoder.WriteBytes(bytes);
+                    break;
+                default:
+                    throw new NotSupportedException($"Unsupported Value type {value.GetType()}");
+            }
+        }
+
+        // --- READ ------------------------------------------------------------
+
+        public static T Read<T>(Decoder decoder, Func<T> factory) where T : AvroValueContainer
+        {
+            var container = factory();
+
+            container.EntityName = decoder.ReadString();
+            container.ClrType = decoder.ReadString();
+
+            var list = new List<PropertyDataRecord>();
+            for (long n = decoder.ReadArrayStart(); n != 0; n = decoder.ReadArrayNext())
+            {
+                for (long i = 0; i < n; i++)
+                {
+                    list.Add(ReadProperty(decoder));
+                }
+            }
+            container.Data = list;
+
+            return container;
+        }
+
+        private static PropertyDataRecord ReadProperty(Decoder decoder)
+        {
+            var record = new PropertyDataRecord();
+
+            int idx = decoder.ReadUnionIndex();
+            if (idx == 1)
+            {
+                record.PropertyIndex = decoder.ReadInt();
+            }
+            else
+            {
+                decoder.ReadNull();
+                record.PropertyIndex = null;
+            }
+
+            record.PropertyName = decoder.ReadString();
+            record.ManagedType = decoder.ReadInt();
+            record.SupportNull = decoder.ReadBoolean();
+
+            idx = decoder.ReadUnionIndex();
+            if (idx == 1)
+            {
+                record.ClrType = decoder.ReadString();
+            }
+            else
+            {
+                decoder.ReadNull();
+                record.ClrType = null;
+            }
+
+            record.Value = ReadValueUnion(decoder);
+
+            return record;
+        }
+
+        private static object ReadValueUnion(Decoder decoder)
+        {
+            int branch = decoder.ReadUnionIndex();
+            switch (branch)
+            {
+                case 0:
+                    decoder.ReadNull();
+                    return null;
+                case 1:
+                    return decoder.ReadBoolean();
+                case 2:
+                    return decoder.ReadInt();
+                case 3:
+                    return decoder.ReadLong();
+                case 4:
+                    return decoder.ReadFloat();
+                case 5:
+                    return decoder.ReadDouble();
+                case 6:
+                    return decoder.ReadString();
+                case 7:
+                    return decoder.ReadBytes();
+                default:
+                    throw new NotSupportedException($"Unsupported union branch {branch}");
+            }
+        }
+    }
+}

--- a/src/net/KEFCore.SerDes.Avro/AvroValueContainerCodec.cs
+++ b/src/net/KEFCore.SerDes.Avro/AvroValueContainerCodec.cs
@@ -48,7 +48,11 @@ namespace MASES.EntityFrameworkCore.KNet.Serialization.Avro.Storage
     public static class AvroValueContainerCodec
     {
         // --- WRITE -----------------------------------------------------------
-
+        /// <summary>
+        /// Encodes <paramref name="container"/> into <paramref name="container"/>
+        /// </summary>
+        /// <param name="container">The <see cref="AvroValueContainer"/> to be written</param>
+        /// <param name="encoder">The <see cref="Encoder"/> instance used for write</param>
         public static void Write(AvroValueContainer container, Encoder encoder)
         {
             encoder.WriteString(container.EntityName);
@@ -147,7 +151,13 @@ namespace MASES.EntityFrameworkCore.KNet.Serialization.Avro.Storage
         }
 
         // --- READ ------------------------------------------------------------
-
+        /// <summary>
+        /// Decodes <typeparamref name="T"/> using <paramref name="decoder"/> allocating objects using <paramref name="factory"/>
+        /// </summary>
+        /// <typeparam name="T">The <see cref="Type"/> to be decoded</typeparam>
+        /// <param name="decoder">The <see cref="Decoder"/> instance with data</param>
+        /// <param name="factory">The factory used to create new object instance of <typeparamref name="T"/></param>
+        /// <returns>A new filled instance of <typeparamref name="T"/></returns>
         public static T Read<T>(Decoder decoder, Func<T> factory) where T : AvroValueContainer
         {
             var container = factory();

--- a/src/net/KEFCore.SerDes.Protobuf/ProtobufKEFCoreSerDes.cs
+++ b/src/net/KEFCore.SerDes.Protobuf/ProtobufKEFCoreSerDes.cs
@@ -28,7 +28,7 @@ using System.Text;
 namespace MASES.EntityFrameworkCore.KNet.Serialization.Protobuf;
 
 /// <summary>
-/// Protobuf base class to define extensions of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://masesgroup.github.io/KNet/articles/usageSerDes.html"/>
+/// Protobuf base class to define extensions of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://knet.masesgroup.com/articles/usageSerDes.html"/>
 /// </summary>
 public static class ProtobufKEFCoreSerDes
 {
@@ -62,7 +62,7 @@ public static class ProtobufKEFCoreSerDes
     /// </summary>
     public static readonly Type DefaultValueContainer = typeof(ProtobufValueContainer<>);
     /// <summary>
-    /// Base class to define key extensions of <see cref="ISerDesSelector{T}"/>, for example <see href="https://masesgroup.github.io/KNet/articles/usageSerDes.html"/>
+    /// Base class to define key extensions of <see cref="ISerDesSelector{T}"/>, for example <see href="https://knet.masesgroup.com/articles/usageSerDes.html"/>
     /// </summary>
     public class Key<T> : ISerDesSelector<T>
     {
@@ -101,7 +101,7 @@ public static class ProtobufKEFCoreSerDes
         /// <inheritdoc cref="ISerDesSelector{T}.NewByteBufferSerDes"/>
         ISerDesBuffered<T> ISerDesSelector<T>.NewByteBufferSerDes() => NewByteBufferSerDes();
         /// <summary>
-        /// Protobuf Key Binary encoder extension of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://masesgroup.github.io/KNet/articles/usageSerDes.html"/>
+        /// Protobuf Key Binary encoder extension of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://knet.masesgroup.com/articles/usageSerDes.html"/>
         /// </summary>
         /// <typeparam name="TData"></typeparam>
         sealed class BinaryRaw<TData> : SerDesRaw<TData>
@@ -212,7 +212,7 @@ public static class ProtobufKEFCoreSerDes
         }
 
         /// <summary>
-        /// Protobuf Key Binary encoder extension of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://masesgroup.github.io/KNet/articles/usageSerDes.html"/> based on <see cref="ByteBuffer"/>
+        /// Protobuf Key Binary encoder extension of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://knet.masesgroup.com/articles/usageSerDes.html"/> based on <see cref="ByteBuffer"/>
         /// </summary>
         /// <typeparam name="TData"></typeparam>
         sealed class BinaryBuffered<TData> : SerDesBuffered<TData>
@@ -320,7 +320,7 @@ public static class ProtobufKEFCoreSerDes
     }
 
     /// <summary>
-    /// Base class to define ValueContainer extensions of <see cref="ISerDesSelector{T}"/>, for example <see href="https://masesgroup.github.io/KNet/articles/usageSerDes.html"/>
+    /// Base class to define ValueContainer extensions of <see cref="ISerDesSelector{T}"/>, for example <see href="https://knet.masesgroup.com/articles/usageSerDes.html"/>
     /// </summary>
     public class ValueContainer<T> : ISerDesSelector<T> where T : class, IMessage<T>
     {
@@ -360,7 +360,7 @@ public static class ProtobufKEFCoreSerDes
         ISerDesBuffered<T> ISerDesSelector<T>.NewByteBufferSerDes() => NewByteBufferSerDes();
 
         /// <summary>
-        /// Protobuf ValueContainer Binary encoder extension of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://masesgroup.github.io/KNet/articles/usageSerDes.html"/> based on <see cref="byte"/> array
+        /// Protobuf ValueContainer Binary encoder extension of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://knet.masesgroup.com/articles/usageSerDes.html"/> based on <see cref="byte"/> array
         /// </summary>
         /// <typeparam name="TData"></typeparam>
         sealed class BinaryRaw<TData> : SerDesRaw<TData> where TData : class, IMessage<TData>
@@ -452,7 +452,7 @@ public static class ProtobufKEFCoreSerDes
         }
 
         /// <summary>
-        /// Protobuf ValueContainer Binary encoder extension of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://masesgroup.github.io/KNet/articles/usageSerDes.html"/> based on <see cref="ByteBuffer"/>
+        /// Protobuf ValueContainer Binary encoder extension of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://knet.masesgroup.com/articles/usageSerDes.html"/> based on <see cref="ByteBuffer"/>
         /// </summary>
         /// <typeparam name="TData"></typeparam>
         sealed class BinaryBuffered<TData> : SerDesBuffered<TData> where TData : class, IMessage<TData>

--- a/src/net/KEFCore.SerDes/DefaultKEFCoreSerDes.cs
+++ b/src/net/KEFCore.SerDes/DefaultKEFCoreSerDes.cs
@@ -26,7 +26,7 @@ using System.Text;
 
 namespace MASES.EntityFrameworkCore.KNet.Serialization.Json;
 /// <summary>
-/// Default base class to define extensions of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://masesgroup.github.io/KNet/articles/usageSerDes.html"/>
+/// Default base class to define extensions of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://knet.masesgroup.com/articles/usageSerDes.html"/>
 /// </summary>
 public static class DefaultKEFCoreSerDes
 {
@@ -43,7 +43,7 @@ public static class DefaultKEFCoreSerDes
     /// </summary>
     public static readonly Type DefaultValueContainer = typeof(DefaultValueContainer<>);
     /// <summary>
-    /// Base class to define key extensions of <see cref="ISerDesSelector{T}"/>, for example <see href="https://masesgroup.github.io/KNet/articles/usageSerDes.html"/>
+    /// Base class to define key extensions of <see cref="ISerDesSelector{T}"/>, for example <see href="https://knet.masesgroup.com/articles/usageSerDes.html"/>
     /// </summary>
     public class Key<T> : ISerDesSelector<T>
     {
@@ -83,7 +83,7 @@ public static class DefaultKEFCoreSerDes
         ISerDesBuffered<T> ISerDesSelector<T>.NewByteBufferSerDes() => NewByteBufferSerDes();
 
         /// <summary>
-        /// Json extension of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://masesgroup.github.io/KNet/articles/usageSerDes.html"/> based on <see cref="byte"/> array
+        /// Json extension of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://knet.masesgroup.com/articles/usageSerDes.html"/> based on <see cref="byte"/> array
         /// </summary>
         /// <typeparam name="TData">The type to be serialized or deserialized. It can be a Primary Key or a ValueContainer like <see cref="DefaultValueContainer{TKey}"/></typeparam>
         sealed class JsonRaw<TData> : SerDesRaw<TData>
@@ -173,7 +173,7 @@ public static class DefaultKEFCoreSerDes
         }
 
         /// <summary>
-        /// Json extension of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://masesgroup.github.io/KNet/articles/usageSerDes.html"/> based on <see cref="ByteBuffer"/>
+        /// Json extension of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://knet.masesgroup.com/articles/usageSerDes.html"/> based on <see cref="ByteBuffer"/>
         /// </summary>
         /// <typeparam name="TData">The type to be serialized or deserialized. It can be a Primary Key or a ValueContainer like <see cref="DefaultValueContainer{TKey}"/></typeparam>
         sealed class JsonBuffered<TData> : SerDesBuffered<TData>
@@ -263,7 +263,7 @@ public static class DefaultKEFCoreSerDes
     }
 
     /// <summary>
-    /// Base class to define ValueContainer extensions of <see cref="ISerDesSelector{T}"/>, for example <see href="https://masesgroup.github.io/KNet/articles/usageSerDes.html"/>
+    /// Base class to define ValueContainer extensions of <see cref="ISerDesSelector{T}"/>, for example <see href="https://knet.masesgroup.com/articles/usageSerDes.html"/>
     /// </summary>
     public class ValueContainer<T> : ISerDesSelector<T>
     {
@@ -303,7 +303,7 @@ public static class DefaultKEFCoreSerDes
         ISerDesBuffered<T> ISerDesSelector<T>.NewByteBufferSerDes() => NewByteBufferSerDes();
 
         /// <summary>
-        /// Json extension of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://masesgroup.github.io/KNet/articles/usageSerDes.html"/> based on <see cref="byte"/> array
+        /// Json extension of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://knet.masesgroup.com/articles/usageSerDes.html"/> based on <see cref="byte"/> array
         /// </summary>
         /// <typeparam name="TData">The type to be serialized or deserialized. It can be a Primary Key or a ValueContainer like <see cref="DefaultValueContainer{TKey}"/></typeparam>
         sealed class JsonRaw<TData> : SerDesRaw<TData>
@@ -389,7 +389,7 @@ public static class DefaultKEFCoreSerDes
         }
 
         /// <summary>
-        /// Json extension of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://masesgroup.github.io/KNet/articles/usageSerDes.html"/> based on <see cref="ByteBuffer"/>
+        /// Json extension of <see cref="SerDes{TData, TJVM}"/>, for example <see href="https://knet.masesgroup.com/articles/usageSerDes.html"/> based on <see cref="ByteBuffer"/>
         /// </summary>
         /// <typeparam name="TData">The type to be serialized or deserialized. It can be a Primary Key or a ValueContainer like <see cref="DefaultValueContainer{TKey}"/></typeparam>
         sealed class JsonBuffered<TData> : SerDesBuffered<TData>

--- a/test/Common/ProgramConfig.cs
+++ b/test/Common/ProgramConfig.cs
@@ -107,6 +107,7 @@ namespace MASES.EntityFrameworkCore.KNet.Test.Common
         public bool UseProtobuf { get; set; } = false;
         public bool UseAvro { get; set; } = false;
         public bool UseAvroBinary { get; set; } = true;
+        public bool UseAvroBinaryLegacy { get; set; } = false;
         public bool EnableKEFCoreTracing { get; set; } = false;
         public bool UseInMemoryProvider { get; set; } = false;
         public bool UseModelBuilder { get; set; } = false;
@@ -171,6 +172,13 @@ namespace MASES.EntityFrameworkCore.KNet.Test.Common
                 context.ValueContainerType = typeof(AvroValueContainer<>);
                 context.ValueSerDesSelectorType = UseAvroBinary ? typeof(AvroKEFCoreSerDes.ValueContainer.Binary<>)
                                                                 : typeof(AvroKEFCoreSerDes.ValueContainer.Json<>);
+            }
+            else if (UseAvroBinaryLegacy)
+            {
+                context.KeySerDesSelectorType = typeof(AvroKEFCoreSerDes.Key.Binary<>);
+                context.ValueContainerType = typeof(AvroValueContainer<>);
+                context.ValueSerDesSelectorType = typeof(AvroKEFCoreSerDes.ValueContainer.Binary<>);
+                AvroKEFCoreSerDes.UseLegacyCodec = true;
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Introduces AvroValueContainerCodec, a hand-written direct codec for AvroValueContainer that bypasses ISpecificRecord Get/Put methods, avoiding boxing allocations per field. Integrates into BinaryRaw and BinaryBuffered serializers with conditional compilation via USE_CUSTOM_CODEC flag to allow fallback to SpecificWriter/Reader. Adds generic constraints to ensure type safety.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
