### PR TITLE
[cherry-pick → release/4.X] Change GitHub token for actions in cherry-pick workflow (#697)

### DIFF
--- a/.github/workflows/cherry-pick.yaml
+++ b/.github/workflows/cherry-pick.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.WORKFLOW_PERMISSION_PAT }}
 
       - name: Configure git
         run: |
@@ -53,7 +53,7 @@ jobs:
         if: env.CONFLICT != 'true'
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.WORKFLOW_PERMISSION_PAT }}
           branch: cherry-pick/${{ matrix.target }}/${{ github.event.pull_request.number }}
           base: ${{ matrix.target }}
           commit-message: "${{ github.event.pull_request.title }} (#${{ github.event.pull_request.number }})"


### PR DESCRIPTION
Automated cherry-pick of PR #697 onto `release/4.X`.

Original PR: https://github.com/masesgroup/KEFCore/pull/697

fix #684