### PR TITLE
[cherry-pick → release/4.X] Remove reviewers from cherry-pick workflow (#700)

### DIFF
--- a/.github/workflows/cherry-pick.yaml
+++ b/.github/workflows/cherry-pick.yaml
@@ -64,7 +64,6 @@ jobs:
             Original PR: ${{ github.event.pull_request.html_url }}
 
             fix #${{ matrix.issue }}
-          reviewers: masesdevelopers
           assignees: masesdevelopers
           labels: cherry-pick
 


### PR DESCRIPTION
Automated cherry-pick of PR #700 onto `release/4.X`.

Original PR: https://github.com/masesgroup/KEFCore/pull/700

fix #684