### PR TITLE
[cherry-pick → release/3.X] Add team-reviewers and update assignees in workflow (#703)

### DIFF
--- a/.github/workflows/cherry-pick.yaml
+++ b/.github/workflows/cherry-pick.yaml
@@ -64,6 +64,8 @@ jobs:
             Original PR: ${{ github.event.pull_request.html_url }}
 
             fix #${{ matrix.issue }}
+          reviewers: ''
+          team-reviewers: mases-reviewer
           assignees: masesdevelopers
           labels: cherry-pick
 


### PR DESCRIPTION
Automated cherry-pick of PR #703 onto `release/3.X`.

Original PR: https://github.com/masesgroup/KEFCore/pull/703

fix #683