### PR TITLE
[cherry-pick → release/4.X] Add CODEOWNERS file for repository ownership (#706)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# .github/CODEOWNERS
+* @masesgroup/mases-reviewer


### PR DESCRIPTION
Automated cherry-pick of PR #706 onto `release/4.X`.

Original PR: https://github.com/masesgroup/KEFCore/pull/706

fix #684