### PR TITLE
Replace cache-based baseline with the proven  gh-api/gh-run-download pattern

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -182,6 +182,7 @@ jobs:
       attestations: write
       packages: write
       id-token: write
+      actions: write
     uses: ./.github/workflows/build_common.yaml
     with:
       EnableDebugLogging: ${{ inputs.EnableDebugLogging || false }}

--- a/.github/workflows/build_common.yaml
+++ b/.github/workflows/build_common.yaml
@@ -1014,15 +1014,20 @@ jobs:
           path: ${{ github.workspace }}/all-test-results
           merge-multiple: true
 
-      - name: Restore previous baseline (latest known-good results from master), if any
-        id: restore-baseline
-        uses: actions/cache/restore@v6
+      - name: Find the latest successful build.yaml run on master
+        id: find-baseline-run
+        shell: bash
+        run: |
+          BASELINE_RUN=$(curl -sL "https://api.github.com/repos/masesgroup/KEFCore/actions/workflows/build.yaml/runs?branch=master&status=success&per_page=1" | jq -r '.workflow_runs[0].id?')
+          echo "run_id=$BASELINE_RUN" >> $GITHUB_OUTPUT
+          echo "Latest successful build.yaml run on master: $BASELINE_RUN"
+
+      - name: Download previous baseline results from that run, if any
+        if: ${{ steps.find-baseline-run.outputs.run_id != '' && steps.find-baseline-run.outputs.run_id != 'null' }}
         continue-on-error: true
-        with:
-          path: ${{ github.workspace }}/baseline-results
-          key: kefcore-test-baseline-none # never matches exactly: forces restore-keys prefix lookup below, so this always resolves to the MOST RECENT baseline saved on master, not a specific run
-          restore-keys: |
-            kefcore-test-baseline-
+        run: gh run download ${{ steps.find-baseline-run.outputs.run_id }} --name kefcore-test-baseline-data --repo masesgroup/KEFCore --dir ${{ github.workspace }}/baseline-results
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN_INHERITED }}
 
       - name: Aggregate into one combined report (compared against baseline when available)
         if: always()
@@ -1058,11 +1063,12 @@ jobs:
           path: ${{ github.workspace }}/test-results-combined-report.md
           retention-days: 30
 
-      - name: Save this run's results as the new baseline
-        # Only master runs establish a new baseline - PR runs compare against it (via restore-keys
-        # above) but must never overwrite it, otherwise a PR could "erase" the real baseline before
-        # its own regressions are ever compared against it.
-        if: ${{ always() && github.ref == 'refs/heads/master' }}
+      - name: Prepare this run's results as next run's potential baseline
+        # Uploaded unconditionally (any branch): whether it's ever actually USED as a baseline is
+        # decided at restore time by "Find the latest successful build.yaml run on master" above,
+        # which only ever looks at master runs - so a PR run uploading this artifact is harmless,
+        # it just never gets selected as anyone's baseline.
+        if: always()
         run: |
           mkdir -p ${{ github.workspace }}/new-baseline
           shopt -s nullglob
@@ -1072,32 +1078,13 @@ jobs:
           fi
         shell: bash
 
-      - uses: actions/cache/save@v6
-        # Cache keys are immutable once written, so each master run saves under a fresh, unique key
-        # (github.run_id) rather than trying to overwrite kefcore-test-baseline-none above; the
-        # restore-keys prefix match in "Restore previous baseline" always picks up the most recent one.
-        if: ${{ always() && github.ref == 'refs/heads/master' }}
+      - uses: actions/upload-artifact@v7
+        if: always()
         with:
+          if-no-files-found: ignore
+          name: kefcore-test-baseline-data
           path: ${{ github.workspace }}/new-baseline
-          key: kefcore-test-baseline-${{ github.run_id }}
-
-      - name: Clean up older baseline caches, keeping only this one
-        if: ${{ always() && github.ref == 'refs/heads/master' }}
-        continue-on-error: true
-        run: |
-          gh extension install actions/gh-actions-cache || true
-          echo "Fetching baseline cache keys..."
-          oldKeys=$(gh actions-cache list --key kefcore-test-baseline- --order desc | cut -f 1 | tail -n +2)
-          set +e
-          for oldKey in $oldKeys
-          do
-              echo "Deleting stale baseline cache: $oldKey"
-              gh actions-cache delete "$oldKey" --confirm
-          done
-          echo "Done"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN_INHERITED }}
-        shell: bash
+          retention-days: 90
 
   final_cleanup:
     needs: [ execute_tests_linux, execute_tests_windows, execute_tests_macos ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The actions/cache restore-keys prefix approach failed in practice: a cache kefcore-test-baseline-<run_id> existed on master, but restore reported 'Cache not found' anyway - GitHub Actions cache cross-branch/scope semantics are stricter and less predictable than assumed, and debugging them further isn't worth it when this exact repo already has a proven, working mechanism for the same problem (fetching an artifact from a specific past run), used for JNet/KNet package fetching.

Reused that same pattern, applied to this repo's own build.yaml:
- Query the GitHub API for the latest successful build.yaml run on the master branch (curl + jq, no auth needed for a public read).
- gh run download that specific run's kefcore-test-baseline-data artifact (continue-on-error: true - fine if it doesn't exist yet, e.g. first run).
- Every aggregate_test_results run (any branch) uploads its own results under that same fixed artifact name - harmless for PR runs, since the lookup step only ever considers master runs, so a PR's own upload can never become anyone's baseline (achieves the same safety property as the previous branch-gated cache save, without needing to gate the upload itself).
- Removed the cache save/cleanup steps entirely; artifacts expire via retention-days (90), no manual cache-key housekeeping needed

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
