### PR TITLE
[PATCH] Require an absolute-ms floor alongside the percent threshold for verdicts

### DIFF
--- a/test/analyze-test-results/README.md
+++ b/test/analyze-test-results/README.md
@@ -68,9 +68,28 @@ For every `(project, framework, testId, cache bucket)` present in **both** runs,
 "Comparison vs baseline" section right after the Headline, with:
 - an overall verdict banner (✅ no regressions / ⚠️ N regression(s) detected);
 - a table of every compared test, sorted regressions-first, each with its own delta % and
-  verdict (`REGRESSION` / `IMPROVEMENT` / `no significant change`), against `--regression-threshold`
-  (percent, default `5.0`) so small run-to-run noise isn't reported as a real change;
+  verdict (`REGRESSION` / `IMPROVEMENT` / `no significant change`);
 - a note on any test present in only one of the two runs (new/removed tests aren't compared).
+
+A verdict only fires when **both** thresholds are exceeded:
+- `--regression-threshold` (percent, default `5.0`)
+- `--regression-threshold-abs-ms` (absolute milliseconds, default `1.0`)
+
+The absolute floor matters in practice: sub-millisecond queries routinely show large percent
+swings between runs (GC pauses, JIT warmup, OS scheduling jitter) that are not real regressions —
+e.g. a query going from 0.058ms to 0.068ms is a +17% delta but only +0.01ms in absolute terms, and
+is correctly reported as "no significant change" with the default thresholds. A real regression on
+a heavier operation (say 6000ms → 6500ms, +8.3% and +500ms) still fires normally. Tune both flags
+to match the scale of what you're measuring:
+
+```bash
+python analyze_results.py \
+  --input after/*.jsonl \
+  --baseline before/*.jsonl \
+  --output report.md \
+  --regression-threshold 5.0 \
+  --regression-threshold-abs-ms 1.0
+```
 
 This is the natural way to check "did this PR make things faster or slower": run the test suite
 before and after the change with `/p:ResultsOutputPath=...` pointed at two different files, then

--- a/test/analyze-test-results/analyze_results.py
+++ b/test/analyze-test-results/analyze_results.py
@@ -125,10 +125,16 @@ def fmt_ms(v: float) -> str:
     return f"{v:.3f}"
 
 
-def verdict(delta_pct: float, threshold_pct: float) -> str:
-    if delta_pct > threshold_pct:
+def verdict(delta_pct: float, delta_ms: float, threshold_pct: float, threshold_abs_ms: float) -> str:
+    # Requires BOTH thresholds to be exceeded, not just the percent one. Rationale (found by
+    # inspecting a real CI report): sub-millisecond queries routinely show 10-40% swings between
+    # runs that are just measurement noise (GC pauses, JIT warmup, OS scheduling jitter) - a percent
+    # threshold alone flags these as REGRESSION/IMPROVEMENT even though the absolute difference is
+    # a fraction of a millisecond and not a real change. Requiring an absolute floor too keeps
+    # sensitivity on operations where a real regression would show up as a meaningful number of ms.
+    if delta_pct > threshold_pct and delta_ms > threshold_abs_ms:
         return "REGRESSION"
-    if delta_pct < -threshold_pct:
+    if delta_pct < -threshold_pct and delta_ms < -threshold_abs_ms:
         return "IMPROVEMENT"
     return "no significant change"
 
@@ -142,7 +148,7 @@ HEADLINE_PATTERN = "iterationtotal"
 
 
 def build_report(records: list[Record], title: str, baseline_records: list[Record] | None = None,
-                  regression_threshold_pct: float = 5.0) -> str:
+                  regression_threshold_pct: float = 5.0, regression_threshold_abs_ms: float = 1.0) -> str:
     lines: list[str] = []
     lines.append(f"# {title}")
     lines.append("")
@@ -187,8 +193,10 @@ def build_report(records: list[Record], title: str, baseline_records: list[Recor
         lines.append("")
         lines.append(f"Delta % and verdict, per `(project, framework, testId, cache)` present in both runs. "
                       f"Positive delta = current run slower (regression); negative = faster (improvement). "
-                      f"Threshold: **±{regression_threshold_pct:.0f}%** — smaller differences are reported as "
-                      f"\"no significant change\" rather than noise.")
+                      f"A verdict only fires when **both** thresholds are exceeded: **±{regression_threshold_pct:.0f}%** "
+                      f"**and** **±{regression_threshold_abs_ms:.2f} ms** absolute — this avoids flagging noise on "
+                      f"sub-millisecond queries, where a large percent swing can still be an insignificant "
+                      f"absolute difference (e.g. GC pauses, JIT warmup, OS scheduling jitter).")
         lines.append("")
 
         current_groups: dict[tuple[str, str, str, bool], list[Record]] = defaultdict(list)
@@ -205,9 +213,10 @@ def build_report(records: list[Record], title: str, baseline_records: list[Recor
             base_stats = summarize(baseline_groups[key])
             if base_stats.median_ms == 0:
                 continue
-            delta_pct = (cur_stats.median_ms - base_stats.median_ms) / base_stats.median_ms * 100
+            delta_ms = cur_stats.median_ms - base_stats.median_ms
+            delta_pct = delta_ms / base_stats.median_ms * 100
             comparison_rows.append((project, framework, test_id, cached, base_stats.median_ms, cur_stats.median_ms,
-                                     delta_pct, verdict(delta_pct, regression_threshold_pct)))
+                                     delta_pct, verdict(delta_pct, delta_ms, regression_threshold_pct, regression_threshold_abs_ms)))
 
         only_in_current = sorted(set(current_groups) - set(baseline_groups))
         only_in_baseline = sorted(set(baseline_groups) - set(current_groups))
@@ -365,6 +374,11 @@ def main() -> int:
     parser.add_argument("--regression-threshold", type=float, default=5.0,
                          help="Percent delta (median elapsed time) beyond which a --baseline comparison is "
                               "called a regression/improvement rather than 'no significant change'. Default: 5.0")
+    parser.add_argument("--regression-threshold-abs-ms", type=float, default=1.0,
+                         help="Absolute delta in milliseconds (median elapsed time) that must ALSO be exceeded, "
+                              "alongside --regression-threshold, for a verdict to be REGRESSION/IMPROVEMENT. "
+                              "Prevents noise on sub-millisecond queries (e.g. a 0.05ms -> 0.07ms swing is a "
+                              "40% delta but an insignificant absolute one) from being flagged. Default: 1.0")
     parser.add_argument("--output", required=True, help="Path to write the Markdown report to")
     parser.add_argument("--title", default="KEFCore test results analysis", help="Report title")
     args = parser.parse_args()
@@ -387,7 +401,8 @@ def main() -> int:
         baseline_records = load_records(baseline_paths)
 
     report = build_report(records, args.title, baseline_records=baseline_records,
-                           regression_threshold_pct=args.regression_threshold)
+                           regression_threshold_pct=args.regression_threshold,
+                           regression_threshold_abs_ms=args.regression_threshold_abs_ms)
 
     out_path = Path(args.output)
     out_path.write_text(report, encoding="utf-8")

--- a/test/analyze-test-results/example/sample-comparison-report.md
+++ b/test/analyze-test-results/example/sample-comparison-report.md
@@ -1,6 +1,6 @@
 # Example: comparison vs baseline (synthetic data)
 
-Generated: 2026-07-26T19:11:37.940950+00:00
+Generated: 2026-07-27T07:47:19.554722+00:00
 
 Total records analyzed: **150**
 
@@ -14,9 +14,9 @@ Median wall-clock time for one full iteration (all queries in that project's fix
 
 ## Comparison vs baseline
 
-Delta % and verdict, per `(project, framework, testId, cache)` present in both runs. Positive delta = current run slower (regression); negative = faster (improvement). Threshold: **�5%** � smaller differences are reported as "no significant change" rather than noise.
+Delta % and verdict, per `(project, framework, testId, cache)` present in both runs. Positive delta = current run slower (regression); negative = faster (improvement). A verdict only fires when **both** thresholds are exceeded: **±5%** **and** **±1.00 ms** absolute — this avoids flagging noise on sub-millisecond queries, where a large percent swing can still be an insignificant absolute difference (e.g. GC pauses, JIT warmup, OS scheduling jitter).
 
-**?? Overall verdict: 1 regression(s) detected** (out of 3 compared tests, 0 improved).
+**⚠️ Overall verdict: 1 regression(s) detected** (out of 3 compared tests, 0 improved).
 
 | Project | Framework | Test | Cache | Baseline median (ms) | Current median (ms) | Delta % | Verdict |
 |---|---|---|---|---|---|---|---|
@@ -40,7 +40,7 @@ None. All reported outcomes had `success: true`.
 
 ## Cached vs non-cached delta
 
-Positive `delta %` means the cached run was slower than the non-cached run for that same test (higher median), computed separately per framework so a difference in EF Core version behavior isn't hidden by averaging across them. For a test whose non-cached path benefits from projection push-down, a consistently positive delta here is expected � projection is intentionally skipped when the per-entity cache is enabled (TTL > 0), so timings should tend back towards the full-entity-fetch cost in that case.
+Positive `delta %` means the cached run was slower than the non-cached run for that same test (higher median), computed separately per framework so a difference in EF Core version behavior isn't hidden by averaging across them. For a test whose non-cached path benefits from projection push-down, a consistently positive delta here is expected — projection is intentionally skipped when the per-entity cache is enabled (TTL > 0), so timings should tend back towards the full-entity-fetch cost in that case.
 
 _No test has records in both cache buckets, so no delta can be computed. Run the same scenario once with `/p:ForwardCacheTimeout=-1` and once with a positive value (e.g. `/p:ForwardCacheTimeout=60`) and pass both result files to this script to populate this section._
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Refs #720.

Found by inspecting a real CI report (test-results-combined-report from a successful run): several 'REGRESSION' verdicts were on sub-millisecond queries with large percent swings but negligible absolute differences, e.g. a scalar-projection query going from 0.058ms to 0.068ms - a +16.4% delta, but only +0.01ms, well within normal measurement noise (GC pauses, JIT warmup, OS scheduling jitter) rather than a real regression.

verdict() now requires BOTH --regression-threshold (percent, unchanged default 5.0) AND the new --regression-threshold-abs-ms (absolute milliseconds, default 1.0) to be exceeded before calling something a REGRESSION or IMPROVEMENT; otherwise it's 'no significant change'. This keeps sensitivity on operations where a real regression shows up as a meaningful number of milliseconds (e.g. 6000ms -> 6500ms, +8.3% and +500ms, still fires normally) while filtering out noise on sub-ms queries.

Verified with a synthetic reproduction of the exact pattern from the real report (0.058ms -> 0.068ms) - now correctly reported as 'no significant change' with the new default thresholds - alongside a genuine ms-scale regression, which still fires as expected. Regenerated the existing baseline-comparison example (example/sample-comparison-report.md) with the new defaults.

This branch is based on current origin/master (post #723/#726 merge), not the earlier feature/structured-test-output branch, so it lands as a clean, independently reviewable delta.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
