### PR TITLE
[PATCH] Add --control-tests: separate environment drift from real regressions

### DIFF
--- a/.github/workflows/build_common.yaml
+++ b/.github/workflows/build_common.yaml
@@ -1049,6 +1049,7 @@ jobs:
             python3 ${{ github.workspace }}/test/analyze-test-results/analyze_results.py \
               --input "${files[@]}" \
               "${baseline_args[@]}" \
+              --control-tests SaveChanges LocalStoreSynchronized DataLoad \
               --output ${{ github.workspace }}/test-results-combined-report.md \
               --title "KEFCore.Benchmark.Test / KEFCore.Complex.Test — combined across all Linux matrix legs (net8.0/net9.0/net10.0, cached/non-cached, all serializations)"
             cat ${{ github.workspace }}/test-results-combined-report.md >> $GITHUB_STEP_SUMMARY

--- a/test/analyze-test-results/README.md
+++ b/test/analyze-test-results/README.md
@@ -95,6 +95,35 @@ This is the natural way to check "did this PR make things faster or slower": run
 before and after the change with `/p:ResultsOutputPath=...` pointed at two different files, then
 pass both to this script.
 
+## Separating a real regression from "the runner was just faster/slower"
+
+CI runners vary between runs (different hardware, shared load on GitHub-hosted runners, etc.),
+which can shift *every* test's timing in the same direction regardless of any code change — making
+a real regression on one test invisible (masked by an overall speedup) or a fake one appear (masked
+as a slowdown) on another. If you know some tests exercise a code path the change under test
+provably doesn't touch (e.g. write-path operations like `SaveChanges`/`LocalStoreSynchronized` when
+the change is read-path only), pass them as `--control-tests` to get an environment-drift estimate
+and adjusted verdicts:
+
+```bash
+python analyze_results.py \
+  --input after/*.jsonl \
+  --baseline before/*.jsonl \
+  --control-tests SaveChanges LocalStoreSynchronized DataLoad \
+  --output report.md
+```
+
+This adds an "Environment drift" note (the median delta measured across the matched control tests)
+and, for every other test, an env-adjusted delta/verdict column *alongside* the raw one — nothing
+is hidden, both numbers are always shown. Control tests themselves are excluded from the scored
+regression/improvement count (their adjusted delta is ~0% by construction, since they define the
+drift) but still listed in the table, tagged `(control)`, for transparency.
+
+Matching is a case-insensitive substring against `testId` — with no `--control-tests`, no drift
+adjustment is computed and the report looks exactly as it did before this feature (opt-in only,
+since deciding what's "unaffected by the change under test" requires knowing what the change
+actually is, which this script can't infer on its own).
+
 ## No dependencies
 
 Standard library only (`json`, `statistics`, `argparse`, `pathlib`) — no `pip install` needed,
@@ -107,6 +136,9 @@ runs with any Python 3.10+.
   one with `use_cache: true`, across three frameworks → `sample-report.md`.
 - `baseline-run.jsonl` / `current-run.jsonl` — a "before" and "after" run with a deliberate 2x
   regression injected into one test, to demonstrate the `--baseline` verdict → `sample-comparison-report.md`.
+- `drift-baseline.jsonl` / `drift-current.jsonl` — a "before"/"after" pair where every test shifts
+  ~-10% (simulating a faster runner) while one read-path test has a real +7% regression hidden
+  underneath that shift → `sample-drift-adjusted-report.md`, demonstrating `--control-tests`.
 
 None of this is real benchmark data — it exists to show the tool end-to-end without needing a
 live Kafka cluster. Regenerate it with:
@@ -122,4 +154,12 @@ python analyze_results.py \
   --baseline example/baseline-run.jsonl \
   --output example/sample-comparison-report.md \
   --title "Example: comparison vs baseline (synthetic data)"
+
+python analyze_results.py \
+  --input example/drift-current.jsonl \
+  --baseline example/drift-baseline.jsonl \
+  --control-tests SaveChanges LocalStoreSynchronized DataLoad \
+  --regression-threshold-abs-ms 0.5 \
+  --output example/sample-drift-adjusted-report.md \
+  --title "Example: environment-drift-adjusted comparison (synthetic data)"
 ```

--- a/test/analyze-test-results/analyze_results.py
+++ b/test/analyze-test-results/analyze_results.py
@@ -148,7 +148,8 @@ HEADLINE_PATTERN = "iterationtotal"
 
 
 def build_report(records: list[Record], title: str, baseline_records: list[Record] | None = None,
-                  regression_threshold_pct: float = 5.0, regression_threshold_abs_ms: float = 1.0) -> str:
+                  regression_threshold_pct: float = 5.0, regression_threshold_abs_ms: float = 1.0,
+                  control_test_patterns: list[str] | None = None) -> str:
     lines: list[str] = []
     lines.append(f"# {title}")
     lines.append("")
@@ -206,7 +207,7 @@ def build_report(records: list[Record], title: str, baseline_records: list[Recor
         for r in baseline_records:
             baseline_groups[(r.project, r.framework, r.testId, r.cache_enabled)].append(r)
 
-        comparison_rows = []
+        raw_rows = []
         for key in sorted(set(current_groups) & set(baseline_groups)):
             project, framework, test_id, cached = key
             cur_stats = summarize(current_groups[key])
@@ -215,8 +216,45 @@ def build_report(records: list[Record], title: str, baseline_records: list[Recor
                 continue
             delta_ms = cur_stats.median_ms - base_stats.median_ms
             delta_pct = delta_ms / base_stats.median_ms * 100
-            comparison_rows.append((project, framework, test_id, cached, base_stats.median_ms, cur_stats.median_ms,
-                                     delta_pct, verdict(delta_pct, delta_ms, regression_threshold_pct, regression_threshold_abs_ms)))
+            is_control = control_test_patterns is not None and any(p in test_id.lower() for p in control_test_patterns)
+            raw_rows.append({"project": project, "framework": framework, "test_id": test_id, "cached": cached,
+                              "base_ms": base_stats.median_ms, "cur_ms": cur_stats.median_ms,
+                              "delta_pct": delta_pct, "is_control": is_control})
+
+        # --- Environment drift: measured from --control-tests (operations known to be unaffected by
+        # the change under test, e.g. write-path operations when the change is read-path only). If the
+        # environment itself got faster/slower between the two runs (different runner hardware, shared
+        # CI load, etc.), these tests should show ~0% delta but won't - that observed shift is the drift
+        # estimate, used below to separate "the code changed" from "the environment changed" for every
+        # OTHER test. Opt-in only: with no --control-tests, no drift adjustment is computed or shown.
+        drift_pct = None
+        if control_test_patterns:
+            control_deltas = [r["delta_pct"] for r in raw_rows if r["is_control"]]
+            lines.append("### Environment drift")
+            lines.append("")
+            if not control_deltas:
+                lines.append(f"_No test matched the given `--control-tests` patterns "
+                              f"(`{', '.join(control_test_patterns)}`), so no drift estimate could be computed._")
+            else:
+                drift_pct = statistics.median(control_deltas)
+                lines.append(f"Median delta across {len(control_deltas)} control test(s) matching "
+                              f"`{', '.join(control_test_patterns)}` (operations assumed unaffected by the change "
+                              f"under test): **{drift_pct:+.1f}%**. This is used as an estimate of environment-only "
+                              f"drift (different runner hardware, shared CI load, etc. between the baseline and "
+                              f"current run) and subtracted from every other test's delta below to get an "
+                              f"\"env-adjusted\" delta and verdict — shown alongside the untouched raw numbers, "
+                              f"never in place of them.")
+            lines.append("")
+
+        comparison_rows = []
+        for r in raw_rows:
+            adj_delta_pct = r["delta_pct"] - drift_pct if drift_pct is not None else None
+            adj_delta_ms = adj_delta_pct / 100 * r["base_ms"] if adj_delta_pct is not None else None
+            raw_verdict = verdict(r["delta_pct"], r["cur_ms"] - r["base_ms"], regression_threshold_pct, regression_threshold_abs_ms)
+            adj_verdict = (verdict(adj_delta_pct, adj_delta_ms, regression_threshold_pct, regression_threshold_abs_ms)
+                           if adj_delta_pct is not None else None)
+            comparison_rows.append((r["project"], r["framework"], r["test_id"], r["cached"], r["base_ms"], r["cur_ms"],
+                                     r["delta_pct"], raw_verdict, adj_delta_pct, adj_verdict, r["is_control"]))
 
         only_in_current = sorted(set(current_groups) - set(baseline_groups))
         only_in_baseline = sorted(set(baseline_groups) - set(current_groups))
@@ -225,26 +263,41 @@ def build_report(records: list[Record], title: str, baseline_records: list[Recor
             lines.append("_No `(project, framework, testId, cache)` combination is present in both the current "
                           "and baseline input, so no comparison can be made._")
         else:
-            regressions = [r for r in comparison_rows if r[7] == "REGRESSION"]
-            improvements = [r for r in comparison_rows if r[7] == "IMPROVEMENT"]
+            # Score using the env-adjusted verdict when available (more meaningful signal), the raw
+            # verdict otherwise. Control tests themselves are excluded from the scored count: by
+            # construction their adjusted delta is ~0 (they define the drift), so counting them as
+            # "compared tests" would just be counting the calibration data as if it were signal too.
+            scored = [r for r in comparison_rows if not r[10]]
+            verdict_index = 9 if drift_pct is not None else 7
+            regressions = [r for r in scored if r[verdict_index] == "REGRESSION"]
+            improvements = [r for r in scored if r[verdict_index] == "IMPROVEMENT"]
+            adjusted_note = " (env-adjusted)" if drift_pct is not None else ""
             if regressions:
-                lines.append(f"**⚠️ Overall verdict: {len(regressions)} regression(s) detected** "
-                              f"(out of {len(comparison_rows)} compared tests, {len(improvements)} improved).")
+                lines.append(f"**⚠️ Overall verdict{adjusted_note}: {len(regressions)} regression(s) detected** "
+                              f"(out of {len(scored)} compared tests, {len(improvements)} improved).")
             else:
-                lines.append(f"**✅ Overall verdict: no regressions detected** "
-                              f"(out of {len(comparison_rows)} compared tests, {len(improvements)} improved).")
+                lines.append(f"**✅ Overall verdict{adjusted_note}: no regressions detected** "
+                              f"(out of {len(scored)} compared tests, {len(improvements)} improved).")
             lines.append("")
-            # Regressions first — the actionable rows — then improvements, then unchanged.
+            # Sort by the same verdict used for scoring; regressions first, then improvements, then unchanged.
             order = {"REGRESSION": 0, "IMPROVEMENT": 1, "no significant change": 2}
-            comparison_rows.sort(key=lambda r: (order[r[7]], r[0], r[1], r[2], r[3]))
-            lines.append("| Project | Framework | Test | Cache | Baseline median (ms) | Current median (ms) | Delta % | Verdict |")
-            lines.append("|---|---|---|---|---|---|---|---|")
-            for project, framework, test_id, cached, base_median, cur_median, delta_pct, v in comparison_rows:
-                cache_label = "cached" if cached else "non-cached"
-                lines.append(
-                    f"| {project} | {framework} | {test_id} | {cache_label} | {fmt_ms(base_median)} | "
-                    f"{fmt_ms(cur_median)} | {delta_pct:+.1f}% | {v} |"
-                )
+            comparison_rows.sort(key=lambda r: (order[r[verdict_index]], r[0], r[1], r[2], r[3]))
+            if drift_pct is None:
+                lines.append("| Project | Framework | Test | Cache | Baseline median (ms) | Current median (ms) | Delta % | Verdict |")
+                lines.append("|---|---|---|---|---|---|---|---|")
+                for project, framework, test_id, cached, base_ms, cur_ms, delta_pct, raw_verdict, _, _, _ in comparison_rows:
+                    cache_label = "cached" if cached else "non-cached"
+                    lines.append(f"| {project} | {framework} | {test_id} | {cache_label} | {fmt_ms(base_ms)} | "
+                                  f"{fmt_ms(cur_ms)} | {delta_pct:+.1f}% | {raw_verdict} |")
+            else:
+                lines.append("| Project | Framework | Test | Cache | Baseline (ms) | Current (ms) | Delta % (raw) | "
+                              "Delta % (env-adjusted) | Verdict (env-adjusted) |")
+                lines.append("|---|---|---|---|---|---|---|---|---|")
+                for project, framework, test_id, cached, base_ms, cur_ms, delta_pct, raw_verdict, adj_pct, adj_v, is_control in comparison_rows:
+                    cache_label = "cached" if cached else "non-cached"
+                    control_tag = " _(control)_" if is_control else ""
+                    lines.append(f"| {project} | {framework} | {test_id}{control_tag} | {cache_label} | {fmt_ms(base_ms)} | "
+                                  f"{fmt_ms(cur_ms)} | {delta_pct:+.1f}% | {adj_pct:+.1f}% | {adj_v} |")
         if only_in_current or only_in_baseline:
             lines.append("")
             if only_in_current:
@@ -379,6 +432,14 @@ def main() -> int:
                               "alongside --regression-threshold, for a verdict to be REGRESSION/IMPROVEMENT. "
                               "Prevents noise on sub-millisecond queries (e.g. a 0.05ms -> 0.07ms swing is a "
                               "40% delta but an insignificant absolute one) from being flagged. Default: 1.0")
+    parser.add_argument("--control-tests", nargs="+", default=None,
+                         help="Optional (used with --baseline): one or more substrings (case-insensitive, matched "
+                              "against testId) identifying tests known to be UNAFFECTED by the change under test "
+                              "(e.g. write-path operations like SaveChanges/LocalStoreSynchronized when the change "
+                              "is read-path only). Their median delta is used as an environment-drift estimate "
+                              "(different runner hardware, shared CI load, etc. between the two runs) and "
+                              "subtracted from every other test's delta to produce an env-adjusted delta/verdict, "
+                              "shown alongside (never instead of) the raw ones.")
     parser.add_argument("--output", required=True, help="Path to write the Markdown report to")
     parser.add_argument("--title", default="KEFCore test results analysis", help="Report title")
     args = parser.parse_args()
@@ -400,9 +461,12 @@ def main() -> int:
             return 1
         baseline_records = load_records(baseline_paths)
 
+    control_test_patterns = [p.lower() for p in args.control_tests] if args.control_tests else None
+
     report = build_report(records, args.title, baseline_records=baseline_records,
                            regression_threshold_pct=args.regression_threshold,
-                           regression_threshold_abs_ms=args.regression_threshold_abs_ms)
+                           regression_threshold_abs_ms=args.regression_threshold_abs_ms,
+                           control_test_patterns=control_test_patterns)
 
     out_path = Path(args.output)
     out_path.write_text(report, encoding="utf-8")

--- a/test/analyze-test-results/example/drift-baseline.jsonl
+++ b/test/analyze-test-results/example/drift-baseline.jsonl
@@ -1,0 +1,5 @@
+{"project": "KEFCore.Complex.Test", "framework": "net9.0", "success": true, "details": null, "forwardCacheTimeout": -1, "reverseCacheTimeout": -1, "testId": "SaveChanges", "elapsedMs": 7000.0}
+{"project": "KEFCore.Complex.Test", "framework": "net9.0", "success": true, "details": null, "forwardCacheTimeout": -1, "reverseCacheTimeout": -1, "testId": "LocalStoreSynchronized", "elapsedMs": 3000.0}
+{"project": "KEFCore.Complex.Test", "framework": "net9.0", "success": true, "details": null, "forwardCacheTimeout": -1, "reverseCacheTimeout": -1, "testId": "DataLoad", "elapsedMs": 6000.0}
+{"project": "KEFCore.Complex.Test", "framework": "net9.0", "success": true, "details": null, "forwardCacheTimeout": -1, "reverseCacheTimeout": -1, "testId": "NestedComplexTypeProjection_BlogId10_TaxCode", "elapsedMs": 400.0}
+{"project": "KEFCore.Complex.Test", "framework": "net9.0", "success": true, "details": null, "forwardCacheTimeout": -1, "reverseCacheTimeout": -1, "testId": "ScalarOnlyProjection_BlogId10_Url", "elapsedMs": 8.0}

--- a/test/analyze-test-results/example/drift-current.jsonl
+++ b/test/analyze-test-results/example/drift-current.jsonl
@@ -1,0 +1,5 @@
+{"project": "KEFCore.Complex.Test", "framework": "net9.0", "success": true, "details": null, "forwardCacheTimeout": -1, "reverseCacheTimeout": -1, "testId": "SaveChanges", "elapsedMs": 6300.0}
+{"project": "KEFCore.Complex.Test", "framework": "net9.0", "success": true, "details": null, "forwardCacheTimeout": -1, "reverseCacheTimeout": -1, "testId": "LocalStoreSynchronized", "elapsedMs": 2700.0}
+{"project": "KEFCore.Complex.Test", "framework": "net9.0", "success": true, "details": null, "forwardCacheTimeout": -1, "reverseCacheTimeout": -1, "testId": "DataLoad", "elapsedMs": 5430.0}
+{"project": "KEFCore.Complex.Test", "framework": "net9.0", "success": true, "details": null, "forwardCacheTimeout": -1, "reverseCacheTimeout": -1, "testId": "NestedComplexTypeProjection_BlogId10_TaxCode", "elapsedMs": 388.8}
+{"project": "KEFCore.Complex.Test", "framework": "net9.0", "success": true, "details": null, "forwardCacheTimeout": -1, "reverseCacheTimeout": -1, "testId": "ScalarOnlyProjection_BlogId10_Url", "elapsedMs": 7.6}

--- a/test/analyze-test-results/example/sample-comparison-report.md
+++ b/test/analyze-test-results/example/sample-comparison-report.md
@@ -1,6 +1,6 @@
 # Example: comparison vs baseline (synthetic data)
 
-Generated: 2026-07-27T07:47:19.554722+00:00
+Generated: 2026-07-28T02:23:32.499167+00:00
 
 Total records analyzed: **150**
 

--- a/test/analyze-test-results/example/sample-drift-adjusted-report.md
+++ b/test/analyze-test-results/example/sample-drift-adjusted-report.md
@@ -1,0 +1,55 @@
+# Example: environment-drift-adjusted comparison (synthetic data)
+
+Generated: 2026-07-28T02:23:46.477451+00:00
+
+Total records analyzed: **5**
+
+## Headline
+
+_No test's `testId` matches the headline pattern (`iterationtotal`), so no single at-a-glance number is available. See "Summary by test" below for the full per-query breakdown._
+
+## Comparison vs baseline
+
+Delta % and verdict, per `(project, framework, testId, cache)` present in both runs. Positive delta = current run slower (regression); negative = faster (improvement). A verdict only fires when **both** thresholds are exceeded: **±5%** **and** **±0.50 ms** absolute — this avoids flagging noise on sub-millisecond queries, where a large percent swing can still be an insignificant absolute difference (e.g. GC pauses, JIT warmup, OS scheduling jitter).
+
+### Environment drift
+
+Median delta across 3 control test(s) matching `savechanges, localstoresynchronized, dataload` (operations assumed unaffected by the change under test): **-10.0%**. This is used as an estimate of environment-only drift (different runner hardware, shared CI load, etc. between the baseline and current run) and subtracted from every other test's delta below to get an "env-adjusted" delta and verdict — shown alongside the untouched raw numbers, never in place of them.
+
+**?? Overall verdict (env-adjusted): 1 regression(s) detected** (out of 2 compared tests, 0 improved).
+
+| Project | Framework | Test | Cache | Baseline (ms) | Current (ms) | Delta % (raw) | Delta % (env-adjusted) | Verdict (env-adjusted) |
+|---|---|---|---|---|---|---|---|---|
+| KEFCore.Complex.Test | net9.0 | NestedComplexTypeProjection_BlogId10_TaxCode | non-cached | 400.000 | 388.800 | -2.8% | +7.2% | REGRESSION |
+| KEFCore.Complex.Test | net9.0 | DataLoad _(control)_ | non-cached | 6000.000 | 5430.000 | -9.5% | +0.5% | no significant change |
+| KEFCore.Complex.Test | net9.0 | LocalStoreSynchronized _(control)_ | non-cached | 3000.000 | 2700.000 | -10.0% | +0.0% | no significant change |
+| KEFCore.Complex.Test | net9.0 | SaveChanges _(control)_ | non-cached | 7000.000 | 6300.000 | -10.0% | +0.0% | no significant change |
+| KEFCore.Complex.Test | net9.0 | ScalarOnlyProjection_BlogId10_Url | non-cached | 8.000 | 7.600 | -5.0% | +5.0% | no significant change |
+
+## Failures
+
+None. All reported outcomes had `success: true`.
+
+## Summary by test
+
+`Framework` is the .NET runtime the test ran under (e.g. `net9.0`), which corresponds directly to the EF Core major version under test. Cache bucket is derived from `forwardCacheTimeout`: `cached` means TTL > 0 (see `KEFCoreCachedValueBufferStore.IsEnabled`), `non-cached` covers zero/negative TTL (the default in test configs, e.g. -1 seconds).
+
+| Project | Framework | Test | Cache | N | Mean (ms) | Median (ms) | Min (ms) | Max (ms) | Stdev (ms) | Success rate |
+|---|---|---|---|---|---|---|---|---|---|---|
+| KEFCore.Complex.Test | net9.0 | DataLoad | non-cached | 1 | 5430.000 | 5430.000 | 5430.000 | 5430.000 | n/a | 100% |
+| KEFCore.Complex.Test | net9.0 | LocalStoreSynchronized | non-cached | 1 | 2700.000 | 2700.000 | 2700.000 | 2700.000 | n/a | 100% |
+| KEFCore.Complex.Test | net9.0 | NestedComplexTypeProjection_BlogId10_TaxCode | non-cached | 1 | 388.800 | 388.800 | 388.800 | 388.800 | n/a | 100% |
+| KEFCore.Complex.Test | net9.0 | SaveChanges | non-cached | 1 | 6300.000 | 6300.000 | 6300.000 | 6300.000 | n/a | 100% |
+| KEFCore.Complex.Test | net9.0 | ScalarOnlyProjection_BlogId10_Url | non-cached | 1 | 7.600 | 7.600 | 7.600 | 7.600 | n/a | 100% |
+
+## Cached vs non-cached delta
+
+Positive `delta %` means the cached run was slower than the non-cached run for that same test (higher median), computed separately per framework so a difference in EF Core version behavior isn't hidden by averaging across them. For a test whose non-cached path benefits from projection push-down, a consistently positive delta here is expected — projection is intentionally skipped when the per-entity cache is enabled (TTL > 0), so timings should tend back towards the full-entity-fetch cost in that case.
+
+_No test has records in both cache buckets, so no delta can be computed. Run the same scenario once with `/p:ForwardCacheTimeout=-1` and once with a positive value (e.g. `/p:ForwardCacheTimeout=60`) and pass both result files to this script to populate this section._
+
+## Cross-framework comparison
+
+For the same project/test/cache-bucket, how the median elapsed time compares across the .NET/EF Core versions the CI matrix runs against. Only shown for combinations with data from more than one framework.
+
+_No test has records from more than one framework, so no cross-framework comparison can be made. Pass result files from multiple `net*.0` runs together to populate this section._


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The comparison feature could be fooled by shared-runner noise: if a CI run's runner happens to be faster/slower overall (different hardware, shared load), every test shifts in the same direction regardless of any code change - a real regression on one test can end up UNDERSTATED (or hidden entirely) by riding on top of an unrelated overall speedup, and a non-existent one can appear the same way. Found by inspecting a real comparison report where SaveChanges (-9.4%) and LocalStoreSynchronized (-15% to -32%) both improved substantially - these are write-path/Kafka consumer-catchup operations that the change under test (a read-path projection optimization) provably does not touch, so a uniform shift across them is a signature of runner variance, not a code effect.

--control-tests takes one or more substrings (case-insensitive, matched against testId) identifying tests known to be unaffected by whatever change is being evaluated. Their median delta becomes the environment- drift estimate, subtracted from every other test's raw delta to produce an env-adjusted delta/verdict shown ALONGSIDE (never instead of) the raw numbers - full transparency, nothing hidden. Control tests themselves are excluded from the scored regression/improvement count (their adjusted delta is ~0% by construction) but still listed, tagged (control).

Opt-in only: with no --control-tests, output is unchanged from before this commit.

Wired into the CI invocation (aggregate_test_results) using SaveChanges/LocalStoreSynchronized/DataLoad as the control set - these are Complex.Test-only testIds, but the estimated drift is applied uniformly to Benchmark.Test's rows too, since both run on the same runner within the same job execution (a documented simplifying assumption, not necessarily true across a long-running job with e.g. thermal throttling, but reasonable as a default).

Verified with a synthetic reproduction of the real report's pattern (-10% drift across control tests masking a genuine +7.2% regression that looks like a -2.8% improvement in the raw numbers) - the env-adjusted verdict correctly surfaces it as REGRESSION. New examples under example/drift-*.jsonl -> sample-drift-adjusted-report.md.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
